### PR TITLE
Velocity control mode & new robot_state/system/io interfaces

### DIFF
--- a/staubli_msgs/CMakeLists.txt
+++ b/staubli_msgs/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(staubli_msgs)
+
+find_package(catkin REQUIRED COMPONENTS
+  industrial_msgs
+  message_generation
+  std_msgs
+)
+
+add_message_files(FILES
+  IOModule.msg
+  IOStates.msg
+)
+
+add_service_files(FILES WriteSingleIO.srv)
+
+generate_messages(DEPENDENCIES
+  industrial_msgs
+  std_msgs
+)
+
+catkin_package(CATKIN_DEPENDS
+  industrial_msgs
+  message_runtime
+  std_msgs
+)

--- a/staubli_msgs/msg/IOModule.msg
+++ b/staubli_msgs/msg/IOModule.msg
@@ -1,0 +1,11 @@
+# Identifier of IO module
+int8 id
+
+# enumerated values
+int8 UNKNOWN=-1
+int8 USER_IN=1
+int8 VALVE_OUT=2
+int8 BASIC_IN=3
+int8 BASIC_OUT=4
+int8 BASIC_IN_2=5
+int8 BASIC_OUT_2=6

--- a/staubli_msgs/msg/IOStates.msg
+++ b/staubli_msgs/msg/IOStates.msg
@@ -1,0 +1,6 @@
+industrial_msgs/TriState[] user_in
+industrial_msgs/TriState[] valve_out
+industrial_msgs/TriState[] basic_io_in
+industrial_msgs/TriState[] basic_io_out
+industrial_msgs/TriState[] basic_io_in_2
+industrial_msgs/TriState[] basic_io_out_2

--- a/staubli_msgs/package.xml
+++ b/staubli_msgs/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>staubli_msgs</name>
+  <version>0.1.0</version>
+  <description>Staubli specific message and service definitions</description>
+  <author>Engin Karlidag</author>
+  <maintainer email="engin.karlidag@gmx.de">Engin Karlidag</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <build_export_depend>message_runtime</build_export_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+  <depend>industrial_msgs</depend>
+  <depend>std_msgs</depend>
+</package>

--- a/staubli_msgs/srv/WriteSingleIO.srv
+++ b/staubli_msgs/srv/WriteSingleIO.srv
@@ -1,0 +1,10 @@
+# Specifies the IO module (e.g. VALVE_OUT, BASIC_OUT, ...)
+staubli_msgs/IOModule module
+
+# Index of pin (e.g. [0-15] for BasicIO module)
+uint8 pin
+
+# Desired state of pin
+bool state
+---
+industrial_msgs/ServiceReturnCode code

--- a/staubli_val3_driver/.clang-format
+++ b/staubli_val3_driver/.clang-format
@@ -1,0 +1,74 @@
+---
+ColumnLimit:    120
+MaxEmptyLinesToKeep: 1
+SortIncludes: false
+
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        2
+UseTab:          Never
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+NamespaceIndentation: None
+ContinuationIndentWidth: 4
+IndentCaseLabels: true
+IndentFunctionDeclarationAfterType: false
+
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+ExperimentalAutoDetectBinPacking: false
+ObjCSpaceBeforeProtocolList: true
+Cpp11BracedListStyle: false
+
+AllowShortBlocksOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+
+BinPackParameters: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+
+PenaltyExcessCharacter: 50
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 1000
+PenaltyBreakFirstLessLess: 10
+PenaltyBreakString: 100
+PenaltyReturnTypeOnItsOwnLine: 50
+
+SpacesBeforeTrailingComments: 2
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping:
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+...

--- a/staubli_val3_driver/.clang-tidy
+++ b/staubli_val3_driver/.clang-tidy
@@ -1,0 +1,50 @@
+---
+Checks:          '-*,
+                  performance-*,
+                  llvm-namespace-comment,
+                  modernize-redundant-void-arg,
+                  modernize-use-nullptr,
+                  modernize-use-default,
+                  modernize-use-override,
+                  modernize-loop-convert,
+                  readability-named-parameter,
+                  readability-redundant-smartptr-get,
+                  readability-redundant-string-cstr,
+                  readability-simplify-boolean-expr,
+                  readability-container-size-empty,
+                  readability-identifier-naming,
+                  '
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '10'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '2'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '2'
+  # type names
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  # method names
+  - key:             readability-identifier-naming.MethodCase
+    value:           camelBack
+  # variable names
+  - key:             readability-identifier-naming.VariableCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ClassMemberSuffix
+    value:           '_'
+  # const static or global variables are UPPER_CASE
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.ClassConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.GlobalVariableCase
+    value:           UPPER_CASE
+...

--- a/staubli_val3_driver/CMakeLists.txt
+++ b/staubli_val3_driver/CMakeLists.txt
@@ -1,15 +1,123 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(staubli_val3_driver)
 
-find_package(catkin REQUIRED)
-catkin_package()
+# enable C++14 standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-if (CATKIN_ENABLE_TESTING)
-  find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml)
+# for clang-tidy
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# check build type
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  message("${PROJECT_NAME}: No build type specified. Selecting 'Release' for best performance")
+  set(CMAKE_BUILD_TYPE Release)
 endif()
+
+# required definitions for simple_message
+add_definitions(-DROS=1)
+add_definitions(-DLINUXSOCKETS=1)
+
+# find catkin dependencies
+find_package(catkin REQUIRED COMPONENTS
+  control_msgs
+  industrial_msgs
+  industrial_robot_client
+  roscpp
+  sensor_msgs
+  simple_message
+  staubli_msgs
+)
+
+# export catkin dependencies
+catkin_package(
+  INCLUDE_DIRS
+    include
+  CATKIN_DEPENDS
+    control_msgs
+    industrial_msgs
+    industrial_robot_client
+    message_runtime
+    roscpp
+    sensor_msgs
+    simple_message
+    staubli_msgs
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+
+###########
+## Build ##
+###########
+
+# Robot state node
+add_executable(staubli_robot_state
+    src/robot_state_node.cpp
+    src/industrial_robot_client/joint_feedback_relay_handler.cpp)
+target_link_libraries(staubli_robot_state
+  industrial_robot_client
+  simple_message
+  ${catkin_LIBRARIES})
+set_target_properties(staubli_robot_state
+  PROPERTIES OUTPUT_NAME robot_state
+  PREFIX "")
+
+# System interface node
+add_executable(staubli_system_interface
+    src/system_interface_node.cpp
+    src/system_interface.cpp
+    src/simple_message/set_drive_power_message.cpp)
+target_link_libraries(staubli_system_interface
+    simple_message
+    ${catkin_LIBRARIES})
+set_target_properties(staubli_system_interface
+  PROPERTIES OUTPUT_NAME system_interface
+  PREFIX "")
+
+# I/O interface node
+add_executable(staubli_io_interface
+    src/io_interface_node.cpp
+    src/io_interface.cpp
+    src/simple_message/io_states.cpp
+    src/simple_message/read_io_message.cpp
+    src/simple_message/write_single_io.cpp
+    src/simple_message/write_single_io_message.cpp)
+add_dependencies(staubli_io_interface ${catkin_EXPORTED_TARGETS})
+target_link_libraries(staubli_io_interface
+    simple_message
+    ${catkin_LIBRARIES})
+set_target_properties(staubli_io_interface
+  PROPERTIES OUTPUT_NAME io_interface
+  PREFIX "")
+
+
+#############
+## Install ##
+#############
+
+install(TARGETS
+  staubli_robot_state
+  staubli_system_interface
+  staubli_io_interface
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 install(DIRECTORY launch val3
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES README.md DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+
+#############
+## Testing ##
+#############
+
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(tests/roslaunch_test.xml)
+endif()

--- a/staubli_val3_driver/README.md
+++ b/staubli_val3_driver/README.md
@@ -57,12 +57,17 @@ From `Main menu`:
 
 The TCP sockets on the CS8 controller/emulator must be configured prior to using the driver, otherwise a runtime error will be displayed on the teach pendant and the driver will not work.
 
-Two sockets (TCP Servers) are required. From `Main menu`:
+Four sockets (TCP Servers) are required. From `Main menu`:
 
 1. Control panel --> I/O --> Socket --> TCP Servers
-2. Configure two sockets
-   * Name: Feedback, Port: 11002, Timeout: -1, Delimiter: 13, Nagle: Off
-   * Name: Motion, Port: 11000, Timeout: -1, Delimiter: 13, Nagle: Off
+2. Configure the following sockets
+
+    | Name   | Port  | Timeout | Delimiter | Nagle |
+    | ---    | ---   | ---     | ---       | ---   |
+    | Motion | 11000 | -1      | 13        | Off   |
+    | System | 11001 | -1      | 13        | Off   |
+    | State  | 11002 | -1      | 13        | Off   |
+    | IO     | 11003 | -1      | 13        | Off   |
 
 ### Run the driver (ROS-I server)
 
@@ -71,7 +76,7 @@ Check that:
 1. The contents of the `val3` folder (both `ros_server` and `ros_libs` folders)
 have been transferred to the Staubli controller
 2. The VAL3 application `ros_server` has been loaded
-3. Both TCP Server sockets have been configured properly
+3. The TCP Server sockets have been configured properly
 
 Then simply press the `Run` button, ensure that `ros_server` is highlighted, then press `F8` (Ok).
 

--- a/staubli_val3_driver/include/staubli_val3_driver/industrial_robot_client/joint_feedback_relay_handler.h
+++ b/staubli_val3_driver/include/staubli_val3_driver/industrial_robot_client/joint_feedback_relay_handler.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JOINT_FEEDBACK_HANDLER_H
+#define JOINT_FEEDBACK_HANDLER_H
+
+#include "control_msgs/FollowJointTrajectoryFeedback.h"
+#include "ros/ros.h"
+#include "sensor_msgs/JointState.h"
+#include "simple_message/message_handler.h"
+#include "simple_message/messages/joint_feedback_message.h"
+
+#include <string>
+#include <vector>
+
+namespace industrial_robot_client
+{
+namespace joint_feedback_relay_handler
+{
+
+/**
+ * \brief Message handler that relays joint positions (converts simple message
+ * types to ROS message types and publishes them)
+ *
+ * THIS CLASS IS NOT THREAD-SAFE
+ *
+ */
+class JointFeedbackRelayHandler : public industrial::message_handler::MessageHandler
+{
+  // since this class defines a different init(), this helps find the base-class init()
+  using industrial::message_handler::MessageHandler::init;
+
+public:
+  /**
+   * \brief Constructor
+   */
+  JointFeedbackRelayHandler(){};
+
+  /**
+   * \brief Class initializer
+   *
+   * \param connection simple message connection that will be used to send replies.
+   * \param joint_names list of joint-names for msg-publishing.
+   *   - Count and order should match data from robot connection.
+   *   - Use blank-name to exclude a joint from publishing.
+   *
+   * \return true on success, false otherwise (an invalid message type)
+   */
+  bool init(industrial::smpl_msg_connection::SmplMsgConnection* connection, std::vector<std::string>& joint_names);
+
+protected:
+  std::vector<std::string> all_joint_names_;
+
+  ros::Publisher pub_joint_control_state_;
+  ros::Publisher pub_joint_sensor_state_;
+  ros::NodeHandle node_;
+
+  /**
+   * \brief Convert joint feedback message into publish message-types
+   *
+   * \param[in] msg_in JointFeedback message from robot connection
+   * \param[out] control_state FollowJointTrajectoryFeedback message for ROS publishing
+   * \param[out] sensor_state JointState message for ROS publishing
+   *
+   * \return true on success, false otherwise
+   */
+  virtual bool createMessages(industrial::joint_feedback_message::JointFeedbackMessage& msg_in,
+                              control_msgs::FollowJointTrajectoryFeedback* control_state,
+                              sensor_msgs::JointState* sensor_state);
+
+  /**
+   * \brief Transform joint positions before publishing.
+   * Can be overridden to implement, e.g. robot-specific joint coupling.
+   *
+   * \param[in] pos_in joint positions, exactly as passed from robot connection.
+   * \param[out] pos_out transformed joint positions (in same order/count as input positions)
+   *
+   * \return true on success, false otherwise
+   */
+  virtual bool transform(const std::vector<double>& pos_in, std::vector<double>* pos_out)
+  {
+    *pos_out = pos_in;  // by default, no transform is applied
+    return true;
+  }
+
+  /**
+   * \brief Select specific joints for publishing
+   *
+   * \param[in] all_joint_pos joint positions, in count/order matching robot connection
+   * \param[in] all_joint_names joint names, matching all_joint_pos
+   * \param[out] pub_joint_pos joint positions selected for publishing
+   * \param[out] pub_joint_names joint names selected for publishing
+   *
+   * \return true on success, false otherwise
+   */
+  virtual bool select(const std::vector<double>& all_joint_pos, const std::vector<std::string>& all_joint_names,
+                      std::vector<double>* pub_joint_pos, std::vector<std::string>* pub_joint_names);
+
+  /**
+   * \brief Callback executed upon receiving a joint feedback message
+   *
+   * \param in incoming message
+   *
+   * \return true on success, false otherwise
+   */
+  bool internalCB(industrial::joint_feedback_message::JointFeedbackMessage& in);
+
+private:
+  /**
+   * \brief Callback executed upon receiving a message
+   *
+   * \param in incoming message
+   *
+   * \return true on success, false otherwise
+   */
+  bool internalCB(industrial::simple_message::SimpleMessage& in);
+};  // class JointFeedbackRelayHandler
+
+}  // namespace joint_feedback_relay_handler
+}  // namespace industrial_robot_client
+
+#endif /* JOINT_FEEDBACK_HANDLER_H */

--- a/staubli_val3_driver/include/staubli_val3_driver/io_interface.h
+++ b/staubli_val3_driver/include/staubli_val3_driver/io_interface.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IO_INTERFACE
+#define IO_INTERFACE
+
+#include "staubli_val3_driver/simple_message/write_single_io.h"
+
+#include "simple_message/smpl_msg_connection.h"
+#include "simple_message/socket/simple_socket.h"
+#include "staubli_msgs/WriteSingleIO.h"
+
+#include <string>
+
+namespace staubli
+{
+namespace io_interface
+{
+
+class IOInterface
+{
+public:
+  static const std::map<int, std::string> MODULE_NAMES;
+
+  IOInterface();
+
+  ~IOInterface();
+
+  bool init(const std::string& default_ip = "", int default_port = industrial::simple_socket::StandardSocketPort::IO);
+
+  void run();
+
+  bool writeSingleIO(staubli_msgs::WriteSingleIO::Request& req, staubli_msgs::WriteSingleIO::Response& res);
+
+  bool writeSingleIO(staubli::simple_message::IOModule moduleId, int pin, bool state);
+
+private:
+  std::shared_ptr<industrial::smpl_msg_connection::SmplMsgConnection> connection_;
+};
+
+}  // namespace io_interface
+}  // namespace staubli
+
+#endif  // IO_INTERFACE

--- a/staubli_val3_driver/include/staubli_val3_driver/simple_message/io_states.h
+++ b/staubli_val3_driver/include/staubli_val3_driver/simple_message/io_states.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IO_STATES_H
+#define IO_STATES_H
+
+#include "simple_message/simple_message.h"
+#include "simple_message/simple_serialize.h"
+#include "simple_message/shared_types.h"
+
+namespace staubli
+{
+namespace simple_message
+{
+
+class IOStates : public industrial::simple_serialize::SimpleSerialize
+{
+public:
+  /**
+   * \brief Default constructor
+   *
+   * This method creates empty data.
+   *
+   */
+  IOStates();
+
+  /**
+   * \brief Destructor
+   *
+   */
+  ~IOStates();
+
+  // Overrides - SimpleSerialize
+  bool load(industrial::byte_array::ByteArray* buffer);
+  bool unload(industrial::byte_array::ByteArray* buffer);
+  unsigned int byteLength()
+  {
+    return 6 * sizeof(industrial::shared_types::shared_int) + 2 * sizeof(industrial::shared_types::shared_bool);
+  }
+
+private:
+  /**
+   * \brief UserIO inputs
+   */
+  industrial::shared_types::shared_int user_in_;
+
+  /**
+   * \brief UserIO outputs (valve)
+   */
+  industrial::shared_types::shared_int valve_out_;
+
+  /**
+   * \brief BasicIO inputs
+   */
+  industrial::shared_types::shared_int basic_in_;
+
+  /**
+   * \brief BasicIO outputs
+   */
+  industrial::shared_types::shared_int basic_out_;
+
+  /**
+   * \brief BasicIO-2 inputs (2nd IO module)
+   */
+  industrial::shared_types::shared_int basic_in_2_;
+
+  /**
+   * \brief BasicIO-2 outputs (2nd IO module)
+   */
+  industrial::shared_types::shared_int basic_out_2_;
+
+  /**
+   * \brief Flag indicating if BasicIO module 1 is working
+   */
+  industrial::shared_types::shared_bool basic_io_valid_;
+
+  /**
+   * \brief Flag indicating if BasicIO module 2 is working
+   */
+  industrial::shared_types::shared_bool basic_io_2_valid_;
+};
+
+}  // namespace simple_message
+}  // namespace staubli
+
+#endif  // IO_STATES_H

--- a/staubli_val3_driver/include/staubli_val3_driver/simple_message/read_io_message.h
+++ b/staubli_val3_driver/include/staubli_val3_driver/simple_message/read_io_message.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef READ_IO_MESSAGE_H
+#define READ_IO_MESSAGE_H
+
+#include "staubli_val3_driver/simple_message/io_states.h"
+
+#include "simple_message/typed_message.h"
+#include "simple_message/simple_message.h"
+#include "simple_message/shared_types.h"
+
+namespace staubli
+{
+namespace simple_message
+{
+
+/**
+ * \brief Class encapsulated read IO message generation methods
+ * (either to or from a industrial::simple_message::SimpleMessage type).
+ *
+ * This message simply wraps the staubli::simple_message::IOStates data type.
+ * The data portion of this typed message matches IOStates.
+ *
+ *
+ * THIS CLASS IS NOT THREAD-SAFE
+ *
+ */
+class ReadIOMessage : public industrial::typed_message::TypedMessage
+{
+public:
+  /**
+   * \brief Default constructor
+   *
+   * This method creates an empty message.
+   *
+   */
+  ReadIOMessage();
+  /**
+   * \brief Destructor
+   *
+   */
+  ~ReadIOMessage();
+  /**
+   * \brief Initializes message from a simple message
+   *
+   * \param simple message to construct from
+   *
+   * \return true if message successfully initialized, otherwise false
+   */
+  bool init(industrial::simple_message::SimpleMessage& msg);
+
+  //  /**
+  //   * \brief Initializes message from a IO states structure
+  //   *
+  //   * \param states structure to initialize from
+  //   *
+  //   */
+  //  void init(IOStates & states);
+
+  /**
+   * \brief Initializes a new read IO message
+   *
+   */
+  void init();
+
+  // Overrides - SimpleSerialize
+  bool load(industrial::byte_array::ByteArray* buffer);
+  bool unload(industrial::byte_array::ByteArray* buffer);
+
+  unsigned int byteLength()
+  {
+    return this->states_.byteLength();
+  }
+
+  IOStates states_;
+};
+
+}  // namespace simple_message
+}  // namespace staubli
+
+#endif  // READ_IO_MESSAGE_H

--- a/staubli_val3_driver/include/staubli_val3_driver/simple_message/set_drive_power_message.h
+++ b/staubli_val3_driver/include/staubli_val3_driver/simple_message/set_drive_power_message.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SET_DRIVE_POWER_MESSAGE_H
+#define SET_DRIVE_POWER_MESSAGE_H
+
+#include "simple_message/typed_message.h"
+#include "simple_message/simple_message.h"
+#include "simple_message/shared_types.h"
+
+namespace staubli
+{
+namespace simple_message
+{
+
+/**
+ * \brief Message representing the industrial_msgs/SetDrivePower service
+ *
+ * THIS CLASS IS NOT THREAD-SAFE
+ *
+ */
+
+class SetDrivePowerMessage : public industrial::typed_message::TypedMessage
+{
+public:
+  /**
+   * \brief Default constructor
+   *
+   * This method creates an empty message.
+   *
+   */
+  SetDrivePowerMessage();
+  /**
+   * \brief Destructor
+   *
+   */
+  ~SetDrivePowerMessage();
+  /**
+   * \brief Initializes message from a simple message
+   *
+   * \param simple message to construct from
+   *
+   * \return true if message successfully initialized, otherwise false
+   */
+  bool init(industrial::simple_message::SimpleMessage& msg);
+
+  /**
+   * \brief Initializes message
+   *
+   * \param drive power value to initialize from
+   *
+   */
+  void init(industrial::shared_types::shared_bool drive_power);
+
+  /**
+   * \brief Initializes a new set drive power message
+   *
+   */
+  void init();
+
+  // Overrides - SimpleSerialize
+  bool load(industrial::byte_array::ByteArray* buffer);
+  bool unload(industrial::byte_array::ByteArray* buffer);
+
+  unsigned int byteLength()
+  {
+    return sizeof(industrial::shared_types::shared_bool);
+  }
+
+  industrial::shared_types::shared_bool drive_power_;
+};
+
+}  // namespace simple_message
+}  // namespace staubli
+
+#endif  // SET_DRIVE_POWER_MESSAGE_H

--- a/staubli_val3_driver/include/staubli_val3_driver/simple_message/write_single_io.h
+++ b/staubli_val3_driver/include/staubli_val3_driver/simple_message/write_single_io.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WRITE_SINGLE_IO_H
+#define WRITE_SINGLE_IO_H
+
+#include "simple_message/simple_message.h"
+#include "simple_message/simple_serialize.h"
+#include "simple_message/shared_types.h"
+
+namespace staubli
+{
+namespace simple_message
+{
+
+/**
+ * \brief Enumeration mirrors staubli_msgs/IOModule definition
+ *
+ */
+namespace IOModules
+{
+
+enum IOModule
+{
+  UNKNOWN = -1,
+  USER_IN = 1,
+  VALVE_OUT = 2,
+  BASIC_IN = 3,
+  BASIC_OUT = 4,
+  BASIC_IN_2 = 5,
+  BASIC_OUT_2 = 6
+};
+
+}  // namespace IOModules
+typedef IOModules::IOModule IOModule;
+
+class WriteSingleIO : public industrial::simple_serialize::SimpleSerialize
+{
+public:
+  /**
+   * \brief Default constructor
+   *
+   * This method creates empty data.
+   *
+   */
+  WriteSingleIO();
+
+  /**
+   * \brief Destructor
+   *
+   */
+  ~WriteSingleIO();
+
+  /**
+   * \brief Initializes an empty WriteSingleIO structure
+   *
+   */
+  void init();
+
+  /**
+   * \brief Initializes a full WriteSingleIO structure
+   *
+   */
+  void init(IOModule moduleId, industrial::shared_types::shared_int pin, industrial::shared_types::shared_bool state);
+
+  IOModule getModuleId()
+  {
+    return IOModule(module_id_);
+  }
+
+  industrial::shared_types::shared_int getPin() const
+  {
+    return pin_;
+  }
+
+  industrial::shared_types::shared_bool getState() const
+  {
+    return state_;
+  }
+
+  void setModuleId(industrial::shared_types::shared_int module_id)
+  {
+    this->module_id_ = module_id;
+  }
+
+  void setPin(industrial::shared_types::shared_int pin)
+  {
+    this->pin_ = pin;
+  }
+
+  void setState(industrial::shared_types::shared_bool state)
+  {
+    this->state_ = state;
+  }
+
+  /**
+   * \brief Copies the passed in value
+   *
+   * \param src (value to copy)
+   */
+  void copyFrom(WriteSingleIO& src);
+
+  // Overrides - SimpleSerialize
+  bool load(industrial::byte_array::ByteArray* buffer);
+  bool unload(industrial::byte_array::ByteArray* buffer);
+  unsigned int byteLength()
+  {
+    return 2 * sizeof(industrial::shared_types::shared_int) + sizeof(industrial::shared_types::shared_bool);
+  }
+
+private:
+  /**
+   * \brief Identifier of the IOModule (see staubli_msgs/IOModule)
+   */
+  industrial::shared_types::shared_int module_id_;
+
+  /**
+   * \brief Index of the pin
+   */
+  industrial::shared_types::shared_int pin_;
+
+  /**
+   * \brief Pin state
+   */
+  industrial::shared_types::shared_bool state_;
+};
+
+}  // namespace simple_message
+}  // namespace staubli
+
+#endif  // WRITE_SINGLE_IO_H

--- a/staubli_val3_driver/include/staubli_val3_driver/simple_message/write_single_io_message.h
+++ b/staubli_val3_driver/include/staubli_val3_driver/simple_message/write_single_io_message.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WRITE_SINGLE_IO_MESSAGE_H
+#define WRITE_SINGLE_IO_MESSAGE_H
+
+#include "staubli_val3_driver/simple_message/write_single_io.h"
+
+#include "simple_message/typed_message.h"
+#include "simple_message/simple_message.h"
+#include "simple_message/shared_types.h"
+
+namespace staubli
+{
+namespace simple_message
+{
+
+/**
+ * \brief Class encapsulated write single IO message generation methods
+ * (either to or from a industrial::simple_message::SimpleMessage type).
+ *
+ * This message simply wraps the staubli::simple_message::WriteSingleIO data type.
+ * The data portion of this typed message matches WriteSingleIO.
+ *
+ *
+ * THIS CLASS IS NOT THREAD-SAFE
+ *
+ */
+class WriteSingleIOMessage : public industrial::typed_message::TypedMessage
+{
+public:
+  /**
+   * \brief Default constructor
+   *
+   * This method creates an empty message.
+   *
+   */
+  WriteSingleIOMessage();
+  /**
+   * \brief Destructor
+   *
+   */
+  ~WriteSingleIOMessage();
+  /**
+   * \brief Initializes message from a simple message
+   *
+   * \param simple message to construct from
+   *
+   * \return true if message successfully initialized, otherwise false
+   */
+  bool init(industrial::simple_message::SimpleMessage& msg);
+
+  /**
+   * \brief Initializes message from a WriteSingleIO structure
+   *
+   * \param states structure to initialize from
+   *
+   */
+  void init(WriteSingleIO& writeSingleIO);
+
+  /**
+   * \brief Initializes a new write single IO message
+   *
+   */
+  void init();
+
+  // Overrides - SimpleSerialize
+  bool load(industrial::byte_array::ByteArray* buffer);
+  bool unload(industrial::byte_array::ByteArray* buffer);
+
+  unsigned int byteLength()
+  {
+    return this->writeSingleIO_.byteLength();
+  }
+
+  WriteSingleIO writeSingleIO_;
+};
+
+}  // namespace simple_message
+}  // namespace staubli
+
+#endif  // WRITE_SINGLE_IO_MESSAGE_H

--- a/staubli_val3_driver/include/staubli_val3_driver/system_interface.h
+++ b/staubli_val3_driver/include/staubli_val3_driver/system_interface.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SYSTEM_INTERFACE
+#define SYSTEM_INTERFACE
+
+#include "staubli_val3_driver/simple_message/set_drive_power_message.h"
+
+#include "industrial_msgs/SetDrivePower.h"
+#include "simple_message/socket/simple_socket.h"
+#include "simple_message/smpl_msg_connection.h"
+
+#include <string>
+
+namespace staubli
+{
+namespace system_interface
+{
+
+class SystemInterface
+{
+public:
+  SystemInterface();
+
+  ~SystemInterface();
+
+  bool init(const std::string& default_ip = "",
+            int default_port = industrial::simple_socket::StandardSocketPorts::SYSTEM);
+
+  void run();
+
+  bool setDrivePowerCb(industrial_msgs::SetDrivePower::Request& req, industrial_msgs::SetDrivePower::Response& res);
+
+  bool setDrivePower(bool value);
+
+private:
+  std::shared_ptr<industrial::smpl_msg_connection::SmplMsgConnection> connection_;
+};
+
+}  // namespace system_interface
+}  // namespace staubli
+
+#endif  // SYSTEM_INTERFACE

--- a/staubli_val3_driver/launch/io_interface.launch
+++ b/staubli_val3_driver/launch/io_interface.launch
@@ -1,0 +1,14 @@
+<!--
+  Wrapper launch file for I/O interface node.
+-->
+<launch>
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" doc="IP of controller" />
+
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+
+  <!-- start the io interface node -->
+  <node name="io_interface" pkg="staubli_val3_driver" type="io_interface" />
+</launch>
+

--- a/staubli_val3_driver/launch/robot_interface_streaming.launch
+++ b/staubli_val3_driver/launch/robot_interface_streaming.launch
@@ -36,6 +36,20 @@
     <arg name="robot_ip" value="$(arg robot_ip)" />
   </include>
 
+  <!-- io_interface: sends IO writes to the controller
+       (using socket connection to robot)
+  -->
+  <include file="$(find staubli_val3_driver)/launch/io_interface.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+  </include>
+
+  <!-- system_interface: sends system commands to the controller
+       (using socket connection to robot)
+  -->
+  <include file="$(find staubli_val3_driver)/launch/system_interface.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+  </include>
+
   <!-- joint_trajectory_action: provides actionlib interface for
        high-level robot control
   -->

--- a/staubli_val3_driver/launch/robot_state.launch
+++ b/staubli_val3_driver/launch/robot_state.launch
@@ -8,6 +8,6 @@
   <!-- put them on the parameter server -->
   <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
 
-  <!-- reuse generic industrial robot client state node -->
-  <node pkg="industrial_robot_client" type="robot_state" name="robot_state" />
+  <!-- start the Staubli specific robot state node -->
+  <node pkg="staubli_val3_driver" type="robot_state" name="robot_state" />
 </launch>

--- a/staubli_val3_driver/launch/system_interface.launch
+++ b/staubli_val3_driver/launch/system_interface.launch
@@ -1,0 +1,13 @@
+<!--
+  Wrapper launch file for system interface node.
+-->
+<launch>
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" doc="IP of controller" />
+
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+
+  <!-- start the system interface node -->
+  <node name="system_interface" pkg="staubli_val3_driver" type="system_interface" />
+</launch>

--- a/staubli_val3_driver/package.xml
+++ b/staubli_val3_driver/package.xml
@@ -27,7 +27,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>industrial_robot_client</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+  <depend>control_msgs</depend>
+  <depend>industrial_msgs</depend>
+  <depend>industrial_robot_client</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>simple_message</depend>
+  <depend>staubli_msgs</depend>
 
   <test_depend>roslaunch</test_depend>
 

--- a/staubli_val3_driver/package.xml
+++ b/staubli_val3_driver/package.xml
@@ -17,6 +17,7 @@
    </p>
   </description>
   <author email="murilo.martins@ocado.com">Murilo Martins</author>
+  <author email="engin.karlidag@gmx.de">Engin Karlidag (Institute for Factory Automation and Production Systems (FAPS))</author>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>Apache 2.0</license>
 

--- a/staubli_val3_driver/src/industrial_robot_client/joint_feedback_relay_handler.cpp
+++ b/staubli_val3_driver/src/industrial_robot_client/joint_feedback_relay_handler.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/industrial_robot_client/joint_feedback_relay_handler.h"
+
+#include "simple_message/log_wrapper.h"
+
+#include <algorithm>
+
+using namespace industrial::joint_feedback_message;
+using namespace industrial::shared_types;
+using namespace industrial::simple_message;
+using namespace industrial::smpl_msg_connection;
+
+namespace industrial_robot_client
+{
+namespace joint_feedback_relay_handler
+{
+
+bool JointFeedbackRelayHandler::init(SmplMsgConnection* connection, std::vector<std::string>& joint_names)
+{
+  this->pub_joint_control_state_ =
+      this->node_.advertise<control_msgs::FollowJointTrajectoryFeedback>("feedback_states", 1);
+
+  this->pub_joint_sensor_state_ = this->node_.advertise<sensor_msgs::JointState>("joint_states", 1);
+
+  // save "complete" joint-name list, preserving any blank entries for later use
+  this->all_joint_names_ = joint_names;
+
+  return init(static_cast<int>(StandardMsgTypes::JOINT_FEEDBACK), connection);
+}
+
+bool JointFeedbackRelayHandler::internalCB(SimpleMessage& in)
+{
+  JointFeedbackMessage joint_fbk_msg;
+
+  if (!joint_fbk_msg.init(in))
+  {
+    LOG_ERROR("Failed to initialize joint feedback message");
+    return false;
+  }
+
+  return internalCB(joint_fbk_msg);
+}
+
+bool JointFeedbackRelayHandler::internalCB(JointFeedbackMessage& in)
+{
+  control_msgs::FollowJointTrajectoryFeedback control_state;
+  sensor_msgs::JointState sensor_state;
+  bool rtn = true;
+
+  if (createMessages(in, &control_state, &sensor_state))
+  {
+    this->pub_joint_control_state_.publish(control_state);
+    this->pub_joint_sensor_state_.publish(sensor_state);
+  }
+  else
+    rtn = false;
+
+  // Reply back to the controller if the sender requested it.
+  if (CommTypes::SERVICE_REQUEST == in.getMessageType())
+  {
+    SimpleMessage reply;
+    in.toReply(reply, rtn ? ReplyTypes::SUCCESS : ReplyTypes::FAILURE);
+    this->getConnection()->sendMsg(reply);
+  }
+
+  return rtn;
+}
+
+bool JointFeedbackRelayHandler::createMessages(JointFeedbackMessage& msg_in,
+                                               control_msgs::FollowJointTrajectoryFeedback* control_state,
+                                               sensor_msgs::JointState* sensor_state)
+{
+  // read joint positions/velocities from JointFeedbackMessage
+  std::vector<double> all_joint_pos(all_joint_names_.size());
+  std::vector<double> all_joint_vel(all_joint_names_.size());
+
+  industrial::joint_data::JointData pos;
+  industrial::joint_data::JointData vel;
+
+  // check if valid
+  bool has_pos = msg_in.getPositions(pos);
+  bool has_vel = msg_in.getVelocities(vel);
+
+  if (has_pos)
+  {
+    for (int i = 0; i < all_joint_names_.size(); ++i)
+    {
+      shared_real value;
+
+      if (pos.getJoint(i, value))
+        all_joint_pos[i] = value;
+      else
+        LOG_ERROR("Failed to parse position value #%d from JointFeedbackMessage", i);
+    }
+  }
+
+  if (has_vel)
+  {
+    for (int i = 0; i < all_joint_names_.size(); ++i)
+    {
+      shared_real value;
+
+      if (vel.getJoint(i, value))
+        all_joint_vel[i] = value;
+      else
+        LOG_ERROR("Failed to parse velocity value #%d from JointFeedbackMessage", i);
+    }
+  }
+
+  // transform joint data?
+
+  // select specific joints for publishing
+  std::vector<double> pub_joint_pos;
+  std::vector<double> pub_joint_vel;
+  std::vector<std::string> pub_joint_names;
+
+  if (has_pos)
+  {
+    if (!select(all_joint_pos, all_joint_names_, &pub_joint_pos, &pub_joint_names))
+    {
+      LOG_ERROR("Failed to select joint positions for publishing");
+      return false;
+    }
+  }
+
+  if (has_vel)
+  {
+    if (!select(all_joint_vel, all_joint_names_, &pub_joint_vel, &pub_joint_names))
+    {
+      LOG_ERROR("Failed to select joint velocities for publishing");
+      return false;
+    }
+  }
+
+  // assign values to messages
+  control_msgs::FollowJointTrajectoryFeedback tmp_control_state;  // always start with a "clean" message
+  tmp_control_state.header.stamp = ros::Time::now();
+  tmp_control_state.joint_names = pub_joint_names;
+  if (has_pos)
+    tmp_control_state.actual.positions = pub_joint_pos;
+  if (has_vel)
+    tmp_control_state.actual.velocities = pub_joint_vel;
+  *control_state = tmp_control_state;
+
+  sensor_msgs::JointState tmp_sensor_state;
+  tmp_sensor_state.header.stamp = ros::Time::now();
+  tmp_sensor_state.name = pub_joint_names;
+  if (has_pos)
+    tmp_sensor_state.position = pub_joint_pos;
+  if (has_vel)
+    tmp_sensor_state.velocity = pub_joint_vel;
+  *sensor_state = tmp_sensor_state;
+
+  return true;
+}
+
+bool JointFeedbackRelayHandler::select(const std::vector<double>& all_joint_pos,
+                                       const std::vector<std::string>& all_joint_names,
+                                       std::vector<double>* pub_joint_pos, std::vector<std::string>* pub_joint_names)
+{
+  ROS_ASSERT(all_joint_pos.size() == all_joint_names.size());
+
+  pub_joint_pos->clear();
+  pub_joint_names->clear();
+
+  // skip over "blank" joint names
+  for (int i = 0; i < all_joint_pos.size(); ++i)
+  {
+    if (all_joint_names[i].empty())
+      continue;
+
+    pub_joint_pos->push_back(all_joint_pos[i]);
+    pub_joint_names->push_back(all_joint_names[i]);
+  }
+
+  return true;
+}
+
+}  // namespace joint_feedback_relay_handler
+}  // namespace industrial_robot_client

--- a/staubli_val3_driver/src/io_interface.cpp
+++ b/staubli_val3_driver/src/io_interface.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/io_interface.h"
+#include "staubli_val3_driver/simple_message/write_single_io_message.h"
+
+#include "ros/ros.h"
+#include "simple_message/simple_message.h"
+#include "simple_message/socket/tcp_client.h"
+
+#include <string>
+
+using namespace industrial::simple_message;
+using namespace industrial::tcp_client;
+using namespace staubli::simple_message;
+
+namespace staubli
+{
+namespace io_interface
+{
+
+// Initialize module names map
+const std::map<int, std::string> IOInterface::MODULE_NAMES = {
+  { staubli::simple_message::IOModule::USER_IN, "UserIn" },
+  { staubli::simple_message::IOModule::BASIC_IN, "BasicIn" },
+  { staubli::simple_message::IOModule::BASIC_OUT, "BasicOut" },
+  { staubli::simple_message::IOModule::VALVE_OUT, "ValveOut" },
+  { staubli::simple_message::IOModule::BASIC_IN_2, "BasicIn-2" },
+  { staubli::simple_message::IOModule::BASIC_OUT_2, "BasicOut-2" }
+};
+
+IOInterface::IOInterface() : connection_(nullptr)
+{
+}
+
+IOInterface::~IOInterface()
+{
+}
+
+bool IOInterface::init(const std::string& default_ip, int default_port)
+{
+  std::string ip;
+  int port;
+
+  // override IP/port with ROS params, if available
+  ros::param::param<std::string>("robot_ip_address", ip, default_ip);
+  ros::param::param<int>("~port", port, default_port);
+
+  // check for valid parameter values
+  if (ip.empty())
+  {
+    ROS_ERROR("No valid robot IP address found. Please set the 'robot_ip_address' parameter");
+    return false;
+  }
+  if (port <= 0 || port > 65535)
+  {
+    ROS_ERROR("No valid robot IP port found. Please set the '~port' parameter");
+    return false;
+  }
+
+  // connection.init() requires "char*", not "const char*"
+  char* ip_addr = strdup(ip.c_str());
+
+  // create and connect client connection
+  auto client = std::make_shared<TcpClient>();
+  bool rtn = client->init(ip_addr, port);
+  free(ip_addr);
+
+  if (!rtn)
+    return false;
+
+  this->connection_ = client;
+  ROS_INFO("io_interface: Connecting (%s:%d)", ip_addr, port);
+
+  return this->connection_->makeConnect();
+}
+
+void IOInterface::run()
+{
+  ros::NodeHandle nh;
+  ros::ServiceServer srv = nh.advertiseService("write_single_io", &IOInterface::writeSingleIO, this);
+  ROS_INFO_STREAM("Service " << srv.getService() << " is ready and running");
+  ros::spin();
+}
+
+bool IOInterface::writeSingleIO(staubli_msgs::WriteSingleIO::Request& req, staubli_msgs::WriteSingleIO::Response& res)
+{
+  std::string module_name;
+
+  // lookup module name for requested module id
+  if (MODULE_NAMES.find(req.module.id) != MODULE_NAMES.end())
+  {
+    module_name = MODULE_NAMES.at(req.module.id);
+  }
+  else
+  {
+    ROS_WARN("Unknown module id given in WriteSingleIO service request!");
+    return false;
+  }
+
+  if (req.state)
+  {
+    ROS_INFO("Trying to set pin %d of module '%s'", req.pin, module_name.c_str());
+  }
+  else
+  {
+    ROS_INFO("Trying to clear pin %d of module '%s'", req.pin, module_name.c_str());
+  }
+
+  if (writeSingleIO(staubli::simple_message::IOModule(req.module.id), req.pin, req.state))
+  {
+    res.code.val = industrial_msgs::ServiceReturnCode::SUCCESS;
+    return true;
+  }
+  else
+  {
+    res.code.val = industrial_msgs::ServiceReturnCode::FAILURE;
+    return false;
+  }
+}
+
+bool IOInterface::writeSingleIO(staubli::simple_message::IOModule moduleId, int pin, bool state)
+{
+  WriteSingleIO write_io;
+  write_io.init(moduleId, pin, state);
+  WriteSingleIOMessage msg;
+  msg.init(write_io);
+  SimpleMessage send, reply;
+  msg.toRequest(send);
+  connection_->sendAndReceiveMsg(send, reply);
+  return (reply.getReplyCode() == ReplyTypes::SUCCESS);
+}
+
+}  // namespace io_interface
+}  // namespace staubli

--- a/staubli_val3_driver/src/io_interface_node.cpp
+++ b/staubli_val3_driver/src/io_interface_node.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/io_interface.h"
+
+#include "ros/ros.h"
+
+using staubli::io_interface::IOInterface;
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "io_interface");
+
+  IOInterface interface;
+
+  if (!interface.init())
+    return 1;
+
+  interface.run();
+
+  return 0;
+}

--- a/staubli_val3_driver/src/robot_state_node.cpp
+++ b/staubli_val3_driver/src/robot_state_node.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/industrial_robot_client/joint_feedback_relay_handler.h"
+
+#include "industrial_robot_client/robot_state_interface.h"
+
+#include "ros/ros.h"
+
+using industrial_robot_client::joint_feedback_relay_handler::JointFeedbackRelayHandler;
+using industrial_robot_client::robot_state_interface::RobotStateInterface;
+
+int main(int argc, char** argv)
+{
+  // initialize node
+  ros::init(argc, argv, "robot_state_interface");
+
+  // launch the default Robot State Interface connection/handlers
+  RobotStateInterface rsi;
+  rsi.init();
+
+  // add the JointFeedback handler
+  JointFeedbackRelayHandler joint_fbk_handler;
+  std::vector<std::string> joint_names = rsi.get_joint_names();
+  joint_fbk_handler.init(rsi.get_connection(), joint_names);
+  rsi.add_handler(&joint_fbk_handler);
+
+  // run the node
+  rsi.run();
+
+  return 0;
+}

--- a/staubli_val3_driver/src/simple_message/io_states.cpp
+++ b/staubli_val3_driver/src/simple_message/io_states.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/simple_message/io_states.h"
+
+#include "simple_message/log_wrapper.h"
+#include "simple_message/shared_types.h"
+
+using namespace industrial::shared_types;
+
+namespace staubli
+{
+namespace simple_message
+{
+
+IOStates::IOStates()
+{
+}
+
+IOStates::~IOStates()
+{
+}
+
+bool IOStates::load(industrial::byte_array::ByteArray* buffer)
+{
+  bool rtn = false;
+
+  LOG_COMM("Executing IO states load");
+
+  if (buffer->load(this->user_in_) && buffer->load(this->valve_out_) && buffer->load(this->basic_in_) &&
+      buffer->load(this->basic_out_) && buffer->load(this->basic_in_2_) && buffer->load(this->basic_out_2_) &&
+      buffer->load(this->basic_io_valid_) && buffer->load(this->basic_io_2_valid_))
+  {
+
+    LOG_COMM("IO states successfully loaded");
+    rtn = true;
+  }
+  else
+  {
+    LOG_COMM("IO states not loaded");
+    rtn = false;
+  }
+
+  return rtn;
+}
+
+bool IOStates::unload(industrial::byte_array::ByteArray* buffer)
+{
+  bool rtn = false;
+
+  LOG_COMM("Executing IO states unload");
+  if (buffer->unload(this->basic_io_2_valid_) && buffer->unload(this->basic_io_valid_) &&
+      buffer->unload(this->basic_out_2_) && buffer->unload(this->basic_in_2_) && buffer->unload(this->basic_out_) &&
+      buffer->unload(this->basic_in_) && buffer->unload(this->valve_out_) && buffer->unload(this->user_in_))
+  {
+
+    rtn = true;
+    LOG_COMM("IO states successfully unloaded");
+  }
+
+  else
+  {
+    LOG_ERROR("Failed to unload IO states");
+    rtn = false;
+  }
+
+  return rtn;
+}
+
+}  // namespace simple_message
+}  // namespace staubli

--- a/staubli_val3_driver/src/simple_message/read_io_message.cpp
+++ b/staubli_val3_driver/src/simple_message/read_io_message.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/simple_message/read_io_message.h"
+
+#include "simple_message/byte_array.h"
+#include "simple_message/log_wrapper.h"
+#include "simple_message/simple_message.h"
+
+using namespace industrial::byte_array;
+using namespace industrial::simple_message;
+
+namespace staubli
+{
+namespace simple_message
+{
+
+ReadIOMessage::ReadIOMessage()
+{
+  this->init();
+}
+
+ReadIOMessage::~ReadIOMessage()
+{
+}
+
+bool ReadIOMessage::init(industrial::simple_message::SimpleMessage& msg)
+{
+  bool rtn = false;
+  ByteArray data = msg.getData();
+  this->init();
+  this->setCommType(msg.getCommType());
+
+  if (data.unload(this->states_))
+  {
+    rtn = true;
+  }
+  else
+  {
+    LOG_ERROR("Failed to unload read IO data");
+  }
+  return rtn;
+}
+
+void ReadIOMessage::init()
+{
+  this->setMessageType(1620);  // TODO: make enum for Stäubli specific standard port numbers
+}
+
+bool ReadIOMessage::load(ByteArray* buffer)
+{
+  bool rtn = false;
+  LOG_COMM("Executing read IO message load");
+  if (buffer->load(this->states_))
+  {
+    rtn = true;
+  }
+  else
+  {
+    rtn = false;
+    LOG_ERROR("Failed to read IO states data");
+  }
+  return rtn;
+}
+
+bool ReadIOMessage::unload(ByteArray* buffer)
+{
+  bool rtn = false;
+  LOG_COMM("Executing read IO message unload");
+
+  if (buffer->unload(this->states_))
+  {
+    rtn = true;
+  }
+  else
+  {
+    rtn = false;
+    LOG_ERROR("Failed to unload read IO data");
+  }
+  return rtn;
+}
+
+}  // namespace simple_message
+}  // namespace staubli

--- a/staubli_val3_driver/src/simple_message/set_drive_power_message.cpp
+++ b/staubli_val3_driver/src/simple_message/set_drive_power_message.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/simple_message/set_drive_power_message.h"
+
+#include "simple_message/byte_array.h"
+#include "simple_message/log_wrapper.h"
+
+using namespace industrial::byte_array;
+using namespace industrial::shared_types;
+using namespace industrial::simple_message;
+
+namespace staubli
+{
+namespace simple_message
+{
+
+SetDrivePowerMessage::SetDrivePowerMessage()
+{
+  this->init();
+}
+
+SetDrivePowerMessage::~SetDrivePowerMessage()
+{
+}
+
+bool SetDrivePowerMessage::init(industrial::simple_message::SimpleMessage& msg)
+{
+  bool rtn = false;
+  ByteArray data = msg.getData();
+  this->init();
+  this->setCommType(msg.getCommType());
+
+  if (data.unload(this->drive_power_))
+  {
+    rtn = true;
+  }
+  else
+  {
+    LOG_ERROR("Failed to unload SetDrivePower data");
+  }
+  return rtn;
+}
+
+void SetDrivePowerMessage::init()
+{
+  this->setMessageType(1610);  // TODO: make enum for Stäubli specific standard port numbers
+}
+
+void SetDrivePowerMessage::init(shared_bool drive_power)
+{
+  this->init();
+  this->drive_power_ = drive_power;
+}
+
+bool SetDrivePowerMessage::load(industrial::byte_array::ByteArray* buffer)
+{
+  bool rtn = false;
+
+  LOG_COMM("Executing SetDrivePower load");
+
+  if (buffer->load(this->drive_power_))
+  {
+
+    LOG_COMM("SetDrivePower successfully loaded");
+    rtn = true;
+  }
+  else
+  {
+    LOG_COMM("SetDrivePower not loaded");
+    rtn = false;
+  }
+
+  return rtn;
+}
+
+bool SetDrivePowerMessage::unload(industrial::byte_array::ByteArray* buffer)
+{
+  bool rtn = false;
+
+  LOG_COMM("Executing SetDrivePower unload");
+  if (buffer->unload(this->drive_power_))
+  {
+
+    rtn = true;
+    LOG_COMM("SetDrivePower successfully unloaded");
+  }
+
+  else
+  {
+    LOG_ERROR("Failed to unload SetDrivePower");
+    rtn = false;
+  }
+
+  return rtn;
+}
+
+}  // namespace simple_message
+}  // namespace staubli

--- a/staubli_val3_driver/src/simple_message/write_single_io.cpp
+++ b/staubli_val3_driver/src/simple_message/write_single_io.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/simple_message/write_single_io.h"
+
+#include "simple_message/byte_array.h"
+#include "simple_message/shared_types.h"
+#include "simple_message/log_wrapper.h"
+
+using namespace industrial::shared_types;
+
+namespace staubli
+{
+namespace simple_message
+{
+
+WriteSingleIO::WriteSingleIO()
+{
+  this->init();
+}
+
+WriteSingleIO::~WriteSingleIO()
+{
+}
+
+void WriteSingleIO::init()
+{
+  this->init(IOModule::UNKNOWN, 0, false);
+}
+
+void WriteSingleIO::init(IOModule module_id, shared_int pin, shared_bool state)
+{
+  this->setModuleId(module_id);
+  this->setPin(pin);
+  this->setState(state);
+}
+
+void WriteSingleIO::copyFrom(WriteSingleIO& src)
+{
+  this->init(src.getModuleId(), src.getPin(), src.getState());
+}
+
+bool WriteSingleIO::load(industrial::byte_array::ByteArray* buffer)
+{
+  bool rtn = false;
+
+  LOG_COMM("Executing WriteSingleIO load");
+
+  if (buffer->load(this->module_id_) && buffer->load(this->pin_) && buffer->load(this->state_))
+  {
+
+    LOG_COMM("WriteSingleIO successfully loaded");
+    rtn = true;
+  }
+  else
+  {
+    LOG_COMM("WriteSingleIO not loaded");
+    rtn = false;
+  }
+
+  return rtn;
+}
+
+bool WriteSingleIO::unload(industrial::byte_array::ByteArray* buffer)
+{
+  bool rtn = false;
+
+  LOG_COMM("Executing WriteSingleIO unload");
+  if (buffer->unload(this->state_) && buffer->unload(this->pin_) && buffer->unload(this->module_id_))
+  {
+    rtn = true;
+    LOG_COMM("WriteSingleIO successfully unloaded");
+  }
+
+  else
+  {
+    LOG_ERROR("Failed to unload WriteSingleIO");
+    rtn = false;
+  }
+
+  return rtn;
+}
+
+}  // namespace simple_message
+}  // namespace staubli

--- a/staubli_val3_driver/src/simple_message/write_single_io_message.cpp
+++ b/staubli_val3_driver/src/simple_message/write_single_io_message.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/simple_message/write_single_io_message.h"
+
+#include "simple_message/byte_array.h"
+#include "simple_message/log_wrapper.h"
+
+using namespace industrial::byte_array;
+using namespace industrial::simple_message;
+
+namespace staubli
+{
+namespace simple_message
+{
+
+WriteSingleIOMessage::WriteSingleIOMessage()
+{
+  this->init();
+}
+
+WriteSingleIOMessage::~WriteSingleIOMessage()
+{
+}
+
+bool WriteSingleIOMessage::init(SimpleMessage& msg)
+{
+  bool rtn = false;
+  ByteArray data = msg.getData();
+  this->init();
+  this->setCommType(msg.getCommType());
+
+  if (data.unload(this->writeSingleIO_))
+  {
+    rtn = true;
+  }
+  else
+  {
+    LOG_ERROR("Failed to unload write single IO data");
+  }
+  return rtn;
+}
+
+void WriteSingleIOMessage::init(WriteSingleIO& writeSingleIO)
+{
+  this->init();
+  this->writeSingleIO_.copyFrom(writeSingleIO);
+}
+
+void WriteSingleIOMessage::init()
+{
+  this->setMessageType(1621);  // TODO: make enum for Stäubli specific standard port numbers
+  this->writeSingleIO_.init();
+}
+
+bool WriteSingleIOMessage::load(ByteArray* buffer)
+{
+  bool rtn;
+  LOG_COMM("Executing write single IO message load");
+
+  if (buffer->load(this->writeSingleIO_))
+  {
+    rtn = true;
+  }
+  else
+  {
+    rtn = false;
+    LOG_ERROR("Failed to load write single IO data");
+  }
+  return rtn;
+}
+
+bool WriteSingleIOMessage::unload(ByteArray* buffer)
+{
+  bool rtn;
+  LOG_COMM("Executing write single IO message unload");
+
+  if (buffer->unload(this->writeSingleIO_))
+  {
+    rtn = true;
+  }
+  else
+  {
+    rtn = false;
+    LOG_ERROR("Failed to unload write single IO data");
+  }
+  return rtn;
+}
+
+}  // namespace simple_message
+}  // namespace staubli

--- a/staubli_val3_driver/src/system_interface.cpp
+++ b/staubli_val3_driver/src/system_interface.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/system_interface.h"
+#include "staubli_val3_driver/simple_message/set_drive_power_message.h"
+
+#include "ros/ros.h"
+#include "industrial_msgs/SetDrivePower.h"
+#include "simple_message/simple_message.h"
+#include "simple_message/smpl_msg_connection.h"
+#include "simple_message/socket/tcp_client.h"
+
+#include <string>
+
+using namespace industrial::simple_message;
+using namespace industrial::tcp_client;
+using namespace staubli::simple_message;
+
+namespace staubli
+{
+namespace system_interface
+{
+
+SystemInterface::SystemInterface() : connection_(nullptr)
+{
+}
+
+SystemInterface::~SystemInterface()
+{
+}
+
+bool SystemInterface::init(const std::string& default_ip, int default_port)
+{
+  std::string ip;
+  int port;
+
+  // override IP/port with ROS params, if available
+  ros::param::param<std::string>("robot_ip_address", ip, default_ip);
+  ros::param::param<int>("~port", port, default_port);
+
+  // check for valid parameter values
+  if (ip.empty())
+  {
+    ROS_ERROR("No valid robot IP address found. Please set the 'robot_ip_address' parameter");
+    return false;
+  }
+  if (port <= 0 || port > 65535)
+  {
+    ROS_ERROR("No valid robot IP port found. Please set the '~port' parameter");
+    return false;
+  }
+
+  // connection.init() requires "char*", not "const char*"
+  char* ip_addr = strdup(ip.c_str());
+
+  // create and connect client connection
+  auto client = std::make_shared<TcpClient>();
+  bool rtn = client->init(ip_addr, port);
+  free(ip_addr);
+
+  if (!rtn)
+    return false;
+
+  this->connection_ = client;
+  ROS_INFO("system_interface: Connecting (%s:%d)", ip_addr, port);
+
+  return this->connection_->makeConnect();
+}
+
+void SystemInterface::run()
+{
+  ros::NodeHandle nh;
+  ros::ServiceServer srv = nh.advertiseService("set_drive_power", &SystemInterface::setDrivePowerCb, this);
+  ROS_INFO_STREAM("Service " << srv.getService() << " is ready and running");
+  ros::spin();
+}
+
+bool SystemInterface::setDrivePowerCb(industrial_msgs::SetDrivePower::Request& req,
+                                      industrial_msgs::SetDrivePower::Response& res)
+{
+  if (req.drive_power)
+    ROS_INFO("Setting drive power ON");
+  else
+    ROS_INFO("Setting drive power OFF");
+
+  if (setDrivePower(req.drive_power))
+  {
+    res.code.val = industrial_msgs::ServiceReturnCode::SUCCESS;
+    return true;
+  }
+  else
+  {
+    res.code.val = industrial_msgs::ServiceReturnCode::FAILURE;
+    return false;
+  }
+}
+
+bool SystemInterface::setDrivePower(bool value)
+{
+  SetDrivePowerMessage msg;
+  SimpleMessage send, reply;
+  msg.init(value);
+  msg.toRequest(send);
+  connection_->sendAndReceiveMsg(send, reply);
+  return reply.getReplyCode() == ReplyType::SUCCESS;
+}
+
+}  // namespace system_interface
+}  // namespace staubli

--- a/staubli_val3_driver/src/system_interface_node.cpp
+++ b/staubli_val3_driver/src/system_interface_node.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Institute for Factory Automation and Production Systems (FAPS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "staubli_val3_driver/system_interface.h"
+
+#include "ros/ros.h"
+
+using staubli::system_interface::SystemInterface;
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "system_interface");
+
+  SystemInterface interface;
+
+  if (!interface.init())
+    return 1;
+
+  interface.run();
+
+  return 0;
+}

--- a/staubli_val3_driver/val3/ros_libs/Body/Body.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Body/Body.dtx
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
   <Datas>
-    <Data name="mNomSpeed" access="private" xsi:type="array" type="mdesc" size="1" />
     <Data name="nData" access="public" xsi:type="array" type="num" size="1" />
   </Datas>
 </Database>

--- a/staubli_val3_driver/val3/ros_libs/Body/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Body/start.pgx
@@ -3,6 +3,7 @@
   <Program name="start">
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.

--- a/staubli_val3_driver/val3/ros_libs/Body/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Body/stop.pgx
@@ -3,6 +3,7 @@
   <Program name="stop">
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.

--- a/staubli_val3_driver/val3/ros_libs/Header/Header.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Header/Header.dtx
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
   <Datas>
-    <Data name="mNomSpeed" access="private" xsi:type="array" type="mdesc" size="1" />
     <Data name="nMsgType" access="public" xsi:type="array" type="num" size="1" />
     <Data name="nCommType" access="public" xsi:type="array" type="num" size="1" />
     <Data name="nReplyCode" access="public" xsi:type="array" type="num" size="1" />

--- a/staubli_val3_driver/val3/ros_libs/Header/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Header/start.pgx
@@ -3,6 +3,7 @@
   <Program name="start">
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.

--- a/staubli_val3_driver/val3/ros_libs/Header/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Header/stop.pgx
@@ -3,6 +3,7 @@
   <Program name="stop">
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.

--- a/staubli_val3_driver/val3/ros_libs/IOInterface/IOInterface.dtx
+++ b/staubli_val3_driver/val3/ros_libs/IOInterface/IOInterface.dtx
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="bBasicIO1" access="public" xsi:type="array" type="bool" size="1">
+    </Data>
+    <Data name="bBasicIO2" access="public" xsi:type="array" type="bool" size="1">
+    </Data>
+    <Data name="diBasicIn" access="private" xsi:type="array" type="dio" size="16">
+      <Value key="0" link="BasicIO-1\%I0" />
+      <Value key="1" link="BasicIO-1\%I1" />
+      <Value key="2" link="BasicIO-1\%I2" />
+      <Value key="3" link="BasicIO-1\%I3" />
+      <Value key="4" link="BasicIO-1\%I4" />
+      <Value key="5" link="BasicIO-1\%I5" />
+      <Value key="6" link="BasicIO-1\%I6" />
+      <Value key="7" link="BasicIO-1\%I7" />
+      <Value key="8" link="BasicIO-1\%I8" />
+      <Value key="9" link="BasicIO-1\%I9" />
+      <Value key="10" link="BasicIO-1\%I10" />
+      <Value key="11" link="BasicIO-1\%I11" />
+      <Value key="12" link="BasicIO-1\%I12" />
+      <Value key="13" link="BasicIO-1\%I13" />
+      <Value key="14" link="BasicIO-1\%I14" />
+      <Value key="15" link="BasicIO-1\%I15" />
+    </Data>
+    <Data name="diBasicIn2" access="private" xsi:type="array" type="dio" size="16">
+      <Value key="0" link="BasicIO-2\%I0" />
+      <Value key="1" link="BasicIO-2\%I1" />
+      <Value key="2" link="BasicIO-2\%I2" />
+      <Value key="3" link="BasicIO-2\%I3" />
+      <Value key="4" link="BasicIO-2\%I4" />
+      <Value key="5" link="BasicIO-2\%I5" />
+      <Value key="6" link="BasicIO-2\%I6" />
+      <Value key="7" link="BasicIO-2\%I7" />
+      <Value key="8" link="BasicIO-2\%I8" />
+      <Value key="9" link="BasicIO-2\%I9" />
+      <Value key="10" link="BasicIO-2\%I10" />
+      <Value key="11" link="BasicIO-2\%I11" />
+      <Value key="12" link="BasicIO-2\%I12" />
+      <Value key="13" link="BasicIO-2\%I13" />
+      <Value key="14" link="BasicIO-2\%I14" />
+      <Value key="15" link="BasicIO-2\%I15" />
+    </Data>
+    <Data name="diBasicOut" access="private" xsi:type="array" type="dio" size="16">
+      <Value key="0" link="BasicIO-1\%Q0" />
+      <Value key="1" link="BasicIO-1\%Q1" />
+      <Value key="2" link="BasicIO-1\%Q2" />
+      <Value key="3" link="BasicIO-1\%Q3" />
+      <Value key="4" link="BasicIO-1\%Q4" />
+      <Value key="5" link="BasicIO-1\%Q5" />
+      <Value key="6" link="BasicIO-1\%Q6" />
+      <Value key="7" link="BasicIO-1\%Q7" />
+      <Value key="8" link="BasicIO-1\%Q8" />
+      <Value key="9" link="BasicIO-1\%Q9" />
+      <Value key="10" link="BasicIO-1\%Q10" />
+      <Value key="11" link="BasicIO-1\%Q11" />
+      <Value key="12" link="BasicIO-1\%Q12" />
+      <Value key="13" link="BasicIO-1\%Q13" />
+      <Value key="14" link="BasicIO-1\%Q14" />
+      <Value key="15" link="BasicIO-1\%Q15" />
+    </Data>
+    <Data name="diBasicOut2" access="private" xsi:type="array" type="dio" size="16">
+      <Value key="0" link="BasicIO-2\%Q0" />
+      <Value key="1" link="BasicIO-2\%Q1" />
+      <Value key="2" link="BasicIO-2\%Q2" />
+      <Value key="3" link="BasicIO-2\%Q3" />
+      <Value key="4" link="BasicIO-2\%Q4" />
+      <Value key="5" link="BasicIO-2\%Q5" />
+      <Value key="6" link="BasicIO-2\%Q6" />
+      <Value key="7" link="BasicIO-2\%Q7" />
+      <Value key="8" link="BasicIO-2\%Q8" />
+      <Value key="9" link="BasicIO-2\%Q9" />
+      <Value key="10" link="BasicIO-2\%Q10" />
+      <Value key="11" link="BasicIO-2\%Q11" />
+      <Value key="12" link="BasicIO-2\%Q12" />
+      <Value key="13" link="BasicIO-2\%Q13" />
+      <Value key="14" link="BasicIO-2\%Q14" />
+      <Value key="15" link="BasicIO-2\%Q15" />
+    </Data>
+    <Data name="diUserIn" access="private" xsi:type="array" type="dio" size="2">
+      <Value key="0" link="usrIn0" />
+      <Value key="1" link="usrIn1" />
+    </Data>
+    <Data name="diValveOut" access="private" xsi:type="array" type="dio" size="2">
+      <Value key="0" link="valve1" />
+      <Value key="1" link="valve2" />
+    </Data>
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/IOInterface/IOInterface.pjx
+++ b/staubli_val3_driver/val3/ros_libs/IOInterface/IOInterface.pjx
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3" >
+  <Parameters version="s7.9.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="init.pgx" />
+    <Program file="readAll.pgx" />
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+    <Program file="writeSingle.pgx" />
+  </Programs>
+  <Database>
+    <Data file="IOInterface.dtx" />
+  </Database>
+  <Libraries>
+    <Library alias="IOModule" path="Disk://ros_libs/IOModule/IOModule.pjx" autoload="true" password="" />
+  </Libraries>
+  <Types>
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/IOInterface/init.pgx
+++ b/staubli_val3_driver/val3/ros_libs/IOInterface/init.pgx
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="init" access="public" >
+    <Locals>
+      <Local name="l_nStatus" type="num" xsi:type="array" size="1" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  logMsg("[INFO] Called IOInterface:init()")
+
+  // init IOModule enum
+  call IOModule:init()
+
+  // check IO status of the BasicIO module
+  l_nStatus = ioStatus(diBasicIn[0])
+  if (l_nStatus >= 0)
+    bBasicIO1=true
+    logMsg("[INFO] BasicIO available (status: "+toString("", l_nStatus)+")")
+  else
+    bBasicIO1=false
+    logMsg("[INFO] BasicIO not available (status: "+toString("", l_nStatus)+")")
+  endIf
+
+  // check IO status of the BasicIO-2 module
+  l_nStatus = ioStatus(diBasicIn2[0])
+  if (l_nStatus >= 0)
+    bBasicIO2=true
+    logMsg("[INFO] BasicIO-2 available (status: "+toString("", l_nStatus)+")")
+  else
+    bBasicIO2=false
+    logMsg("[INFO] BasicIO-2 not available (status: "+toString("", l_nStatus)+")")
+  endIf
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/IOInterface/readAll.pgx
+++ b/staubli_val3_driver/val3/ros_libs/IOInterface/readAll.pgx
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="readAll" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_nUserIn" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nValveOut" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nBasicIn" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nBasicOut" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nBasicIn2" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nBasicOut2" type="num" use="reference" xsi:type="element" dimensions="1" />
+    </Parameters>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+    
+  x_nUserIn=dioGet(diUserIn)
+  x_nValveOut=dioGet(diValveOut)
+  
+  if (bBasicIO1)
+    x_nBasicIn=dioGet(diBasicIn)
+    x_nBasicOut=dioGet(diBasicOut)
+  else
+    x_nBasicIn=0
+    x_nBasicOut=0
+  endIf
+  
+  if (bBasicIO2)
+    x_nBasicIn2=dioGet(diBasicIn)
+    x_nBasicOut2=dioGet(diBasicOut)
+  else
+    x_nBasicIn2=0
+    x_nBasicOut2=0
+  endIf
+  
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/IOInterface/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/IOInterface/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="start" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/IOInterface/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/IOInterface/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="stop" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/IOInterface/writeSingle.pgx
+++ b/staubli_val3_driver/val3/ros_libs/IOInterface/writeSingle.pgx
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="writeSingle" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_nModuleId" type="num" use="value" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nPin" type="num" use="value" xsi:type="element" dimensions="1" />
+      <Parameter name="x_bState" type="bool" use="value" xsi:type="element" dimensions="1" />
+      <Parameter name="x_bSuccess" type="bool" use="reference" xsi:type="element" dimensions="1" />
+    </Parameters>
+    <Locals>
+      <Local name="l_diSignal" type="dio" xsi:type="array" size="1" />
+      <Local name="l_nPins" type="num" xsi:type="array" size="1" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  x_bSuccess=true
+
+  // get max pin count for given module
+  switch x_nModuleId
+    case IOModule:USER_IN,IOModule:VALVE_OUT
+      l_nPins=2
+    break
+    case IOModule:BASIC_IN,IOModule:BASIC_OUT,IOModule:BASIC_IN_2,IOModule:BASIC_OUT_2
+      l_nPins=16
+    break
+    default
+      x_bSuccess=false
+    break
+  endSwitch
+
+  // return if unknown module id was given
+  if (x_bSuccess==false)
+    popUpMsg("Error! Unknown module id: "+toString("",x_nModuleId))
+    return
+  endIf
+
+  // check if pin index is out of range
+  if (x_nPin>=l_nPins)
+    popUpMsg("Error! Trying to set pin "+toString("",x_nPin)+" of module "+toString("",x_nModuleId))
+    x_bSuccess=false
+    return
+  endIf
+
+  // link signal source to local variable if possible
+  switch x_nModuleId
+    case IOModule:USER_IN
+      dioLink(l_diSignal,diUserIn[x_nPin])
+    break
+    case IOModule:VALVE_OUT
+      dioLink(l_diSignal,diValveOut[x_nPin])
+    break
+    case IOModule:BASIC_IN
+      if (bBasicIO1)
+        dioLink(l_diSignal,diBasicIn[x_nPin])
+      else
+        x_bSuccess=false
+      endIf
+    break
+    case IOModule:BASIC_OUT
+      if (bBasicIO1)
+        dioLink(l_diSignal,diBasicOut[x_nPin])
+      else
+        x_bSuccess=false
+      endIf
+    break
+    case IOModule:BASIC_IN_2
+      if (bBasicIO2)
+        dioLink(l_diSignal,diBasicIn2[x_nPin])
+      else
+        x_bSuccess=false
+      endIf
+    break
+    case IOModule:BASIC_OUT_2
+      if (bBasicIO2)
+        dioLink(l_diSignal,diBasicOut2[x_nPin])
+      else
+        x_bSuccess=false
+      endIf
+    break
+  endSwitch
+
+  // set dio if linked successfully
+  if (x_bSuccess)
+    l_diSignal=x_bState
+  endIf
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/IOModule/IOModule.dtx
+++ b/staubli_val3_driver/val3/ros_libs/IOModule/IOModule.dtx
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="BASIC_IN" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+    <Data name="BASIC_IN_2" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+    <Data name="BASIC_OUT" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+    <Data name="BASIC_OUT_2" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+    <Data name="UNKNOWN" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+    <Data name="USER_IN" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+    <Data name="VALVE_OUT" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/IOModule/IOModule.pjx
+++ b/staubli_val3_driver/val3/ros_libs/IOModule/IOModule.pjx
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3" >
+  <Parameters version="s7.9.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="init.pgx" />
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="IOModule.dtx" />
+  </Database>
+  <Libraries>
+  </Libraries>
+  <Types>
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/IOModule/init.pgx
+++ b/staubli_val3_driver/val3/ros_libs/IOModule/init.pgx
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="init" access="public" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  UNKNOWN     = -1
+  USER_IN     =  1
+  VALVE_OUT   =  2
+  BASIC_IN    =  3
+  BASIC_OUT   =  4
+  BASIC_IN_2  =  5
+  BASIC_OUT_2 =  6
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/IOModule/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/IOModule/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="start" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/IOModule/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/IOModule/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="stop" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/MotionCfgVel/MotionCfgVel.dtx
+++ b/staubli_val3_driver/val3/ros_libs/MotionCfgVel/MotionCfgVel.dtx
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="fReference" access="public" xsi:type="array" type="frame" size="1">
+      <Value key="0" fatherId="world[0]" />
+    </Data>
+    <Data name="mMaxSpeed" access="public" xsi:type="array" type="mdesc" size="1" />
+    <Data name="tTool" access="public" xsi:type="array" type="tool" size="1">
+      <Value key="0" fatherId="flange[0]" ioLink="valve1" />
+    </Data>
+    <Data name="nCmdType" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/MotionCfgVel/MotionCfgVel.pjx
+++ b/staubli_val3_driver/val3/ros_libs/MotionCfgVel/MotionCfgVel.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="MotionCfgVel.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/MotionCfgVel/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/MotionCfgVel/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/MotionCfgVel/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/MotionCfgVel/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/MotionCmdVel/MotionCmdVel.dtx
+++ b/staubli_val3_driver/val3/ros_libs/MotionCmdVel/MotionCmdVel.dtx
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="nSequence" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nVelCmd" access="public" xsi:type="array" type="num" size="6" />
+    <Data name="nCmdType" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/MotionCmdVel/MotionCmdVel.pjx
+++ b/staubli_val3_driver/val3/ros_libs/MotionCmdVel/MotionCmdVel.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="MotionCmdVel.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/MotionCmdVel/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/MotionCmdVel/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/MotionCmdVel/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/MotionCmdVel/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/SimpleMessage.dtx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/SimpleMessage.dtx
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="CommType" access="public" xsi:type="array" type="_CommType" size="1">
+      <Value key="0">
+        <Field name="INVALID" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="SERVICE_REPLY" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="SERVICE_REQUEST" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="TOPIC" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="MsgType" access="public" xsi:type="array" type="_MsgType" size="1">
+      <Value key="0">
+        <Field name="GET_VERSION" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="JOINT_FEEDBACK" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="JOINT_POSITION" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="JOINT_TRAJ" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="JOINT_TRAJ_PT" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="JOINT_TRAJ_PT_F" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="PING" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="STATUS" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="ReplyCode" access="public" xsi:type="array" type="_ReplyCode" size="1">
+      <Value key="0">
+        <Field name="FAILURE" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="INVALID" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="SUCCESS" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="SpecialSeqVal" access="public" xsi:type="array" type="_SpecialSeqVal" size="1">
+      <Value key="0">
+        <Field name="END_TRAJECTORY" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="START_TRAJ_DOWN" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="START_TRAJ_STRE" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="STOP_TRAJECTORY" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/SimpleMessage.pjx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/SimpleMessage.pjx
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3" >
+  <Parameters version="s7.9.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="encPrefixHeader.pgx" />
+    <Program file="init.pgx" />
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="SimpleMessage.dtx" />
+  </Database>
+  <Libraries>
+  </Libraries>
+  <Types>
+    <Type name="_MsgType" path="./_MsgType/MsgType.pjx" />
+    <Type name="_CommType" path="./_CommType/CommType.pjx" />
+    <Type name="_ReplyCode" path="./_ReplyCode/ReplyCode.pjx" />
+    <Type name="Prefix" path="Disk://ros_libs/Prefix/Prefix.pjx" />
+    <Type name="Header" path="Disk://ros_libs/Header/Header.pjx" />
+    <Type name="_SpecialSeqVal" path="./_SpecialSeqVal/SpecialSeqVal.pjx" />
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_CommType/CommType.dtx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_CommType/CommType.dtx
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="INVALID" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="TOPIC" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="SERVICE_REQUEST" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="SERVICE_REPLY" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_CommType/CommType.pjx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_CommType/CommType.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="CommType.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_CommType/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_CommType/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_CommType/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_CommType/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_MsgType/MsgType.dtx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_MsgType/MsgType.dtx
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="PING" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="GET_VERSION" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="JOINT_POSITION" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="JOINT_TRAJ" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="JOINT_TRAJ_PT" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="JOINT_TRAJ_PT_F" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="JOINT_FEEDBACK" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="STATUS" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_MsgType/MsgType.pjx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_MsgType/MsgType.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="MsgType.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_MsgType/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_MsgType/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_MsgType/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_MsgType/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_ReplyCode/ReplyCode.dtx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_ReplyCode/ReplyCode.dtx
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="INVALID" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="SUCCESS" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="FAILURE" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_ReplyCode/ReplyCode.pjx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_ReplyCode/ReplyCode.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="ReplyCode.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_ReplyCode/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_ReplyCode/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_ReplyCode/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_ReplyCode/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_SpecialSeqVal/SpecialSeqVal.dtx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_SpecialSeqVal/SpecialSeqVal.dtx
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="START_TRAJ_DOWN" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="START_TRAJ_STRE" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="END_TRAJECTORY" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="STOP_TRAJECTORY" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_SpecialSeqVal/SpecialSeqVal.pjx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_SpecialSeqVal/SpecialSeqVal.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="SpecialSeqVal.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_SpecialSeqVal/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_SpecialSeqVal/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/_SpecialSeqVal/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/_SpecialSeqVal/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/encPrefixHeader.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/encPrefixHeader.pgx
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="encPrefixHeader" access="public">
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
+      <Parameter name="x_pPrefix" type="Prefix" xsi:type="element" use="reference" />
+      <Parameter name="x_hHeader" type="Header" xsi:type="element" use="reference" />
+    </Parameters>
+    <Code><![CDATA[begin
+  // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+  
+  // copy of ros_server/encPrefixHeader.pgx
+
+  // encode prefix length
+  toBinary(x_pPrefix.nLength,1,"-4l",x_pPrefix.nData)
+
+  // encode header data
+  toBinary(x_hHeader.nMsgType,1,"-4l",x_hHeader.nData)
+  toBinary(x_hHeader.nCommType,1,"-4l",x_hHeader.nData[4])
+  toBinary(x_hHeader.nReplyCode,1,"-4l",x_hHeader.nData[8])
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/init.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/init.pgx
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="init" access="public">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // initializing the type IDs for messages part of the standardized Simple Message message set
+  // (see https://github.com/ros-industrial/rep/blob/master/rep-I0004.rst#standard-messages)
+  // (or  http://docs.ros.org/kinetic/api/simple_message/html/namespaceindustrial_1_1simple__message_1_1StandardMsgTypes.html)
+  //
+  // NOTE:
+  //
+  //   The custom Staubli specific message IDs are part of a different
+  //   library "Staubli" to emphasize that those are non-standard.
+  //   Furthermore the limitation of variable names to max. 15 characters in VAL3
+  //   makes it difficult to assign names which are self-explanatory. So the library
+  //   names are used like a prefix (e.g. Staubli:MsgType.ALTER_CMD)
+  //
+  MsgType.PING            = 1
+  MsgType.GET_VERSION     = 2
+  
+  MsgType.JOINT_POSITION  = 10
+  MsgType.JOINT_TRAJ_PT   = 11
+  MsgType.JOINT_TRAJ      = 12
+  MsgType.STATUS          = 13
+  MsgType.JOINT_TRAJ_PT_F = 14
+  MsgType.JOINT_FEEDBACK  = 15
+  
+  // initialize communication types
+  // (see https://github.com/gavanderhoorn/rep-ros-i/blob/retrospective_simple_msg/rep-ixxxx.rst#communication-types)
+  // (or  http://docs.ros.org/kinetic/api/simple_message/html/namespaceindustrial_1_1simple__message_1_1CommTypes.html)
+  CommType.INVALID         = 0
+  CommType.TOPIC           = 1
+  CommType.SERVICE_REQUEST = 2
+  CommType.SERVICE_REPLY   = 3
+  
+  // initialize reply codes
+  // (see https://github.com/gavanderhoorn/rep-ros-i/blob/retrospective_simple_msg/rep-ixxxx.rst#reply-codes)
+  // (or  http://docs.ros.org/kinetic/api/simple_message/html/namespaceindustrial_1_1simple__message_1_1ReplyTypes.html)
+  ReplyCode.INVALID = 0
+  ReplyCode.SUCCESS = 1
+  ReplyCode.FAILURE = 2
+  
+  // initialize special sequence values
+  // (see https://github.com/gavanderhoorn/rep-ros-i/blob/retrospective_simple_msg/rep-ixxxx.rst#special-sequence-numbers)
+  // (or http://docs.ros.org/kinetic/api/simple_message/html/namespaceindustrial_1_1joint__traj__pt_1_1SpecialSeqValues.html)
+  // (or https://github.com/ros-industrial/industrial_core/blob/kinetic-devel/simple_message/include/simple_message/joint_traj_pt.h#L54)
+  SpecialSeqVal.START_TRAJ_DOWN = -1
+  SpecialSeqVal.START_TRAJ_STRE = -2
+  SpecialSeqVal.END_TRAJECTORY  = -3
+  SpecialSeqVal.STOP_TRAJECTORY = -4
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="start" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/SimpleMessage/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/SimpleMessage/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="stop" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/SetDrivePwrMsg/SetDrivePwrMsg.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/SetDrivePwrMsg/SetDrivePwrMsg.dtx
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="body" access="public" xsi:type="array" type="Body" size="1">
+      <Value key="0">
+        <Field name="nData" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="header" access="public" xsi:type="array" type="Header" size="1">
+      <Value key="0">
+        <Field name="nCommType" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="nData" xsi:type="array" type="num" size="12">
+        </Field>
+        <Field name="nMsgType" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="nReplyCode" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="prefix" access="public" xsi:type="array" type="Prefix" size="1">
+      <Value key="0">
+        <Field name="nData" xsi:type="array" type="num" size="4">
+        </Field>
+        <Field name="nLength" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="bDrivePower" access="public" xsi:type="array" type="bool" size="1">
+    </Data>
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/SetDrivePwrMsg/SetDrivePwrMsg.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/SetDrivePwrMsg/SetDrivePwrMsg.pjx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3" >
+  <Parameters version="s7.9.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="SetDrivePwrMsg.dtx" />
+  </Database>
+  <Libraries>
+  </Libraries>
+  <Types>
+    <Type name="Body" path="Disk://ros_libs/Body/Body.pjx" />
+    <Type name="Header" path="Disk://ros_libs/Header/Header.pjx" />
+    <Type name="Prefix" path="Disk://ros_libs/Prefix/Prefix.pjx" />
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/SetDrivePwrMsg/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/SetDrivePwrMsg/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="start" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/SetDrivePwrMsg/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/SetDrivePwrMsg/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="stop" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/Staubli.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/Staubli.dtx
@@ -1,0 +1,281 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="setDrvPwrAck" access="public" xsi:type="array" type="SetDrivePwrMsg" size="1">
+      <Value key="0">
+        <Field name="bDrivePower" xsi:type="array" type="bool" size="1" />
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="setDrvPwrMsg" access="public" xsi:type="array" type="SetDrivePwrMsg" size="1">
+      <Value key="0">
+        <Field name="bDrivePower" xsi:type="array" type="bool" size="1" />
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="velCfgAck" access="public" xsi:type="array" type="VelocityCfgMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="68" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="76" />
+            </Field>
+          </Value>
+        </Field>
+        <Field name="velCfg" xsi:type="array" type="VelocityCfg" size="1">
+          <Value key="0">
+            <Field name="nAccel" xsi:type="array" type="num" size="1" />
+            <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+            <Field name="nRefFrameVec" xsi:type="array" type="num" size="6" />
+            <Field name="nRotVel" xsi:type="array" type="num" size="1" />
+            <Field name="nToolVec" xsi:type="array" type="num" size="6" />
+            <Field name="nTransVel" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="velCfgMsg" access="public" xsi:type="array" type="VelocityCfgMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="68" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="velCfg" xsi:type="array" type="VelocityCfg" size="1">
+          <Value key="0">
+            <Field name="nAccel" xsi:type="array" type="num" size="1" />
+            <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+            <Field name="nRefFrameVec" xsi:type="array" type="num" size="6" />
+            <Field name="nRotVel" xsi:type="array" type="num" size="1" />
+            <Field name="nToolVec" xsi:type="array" type="num" size="6" />
+            <Field name="nTransVel" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="velCmdAck" access="public" xsi:type="array" type="VelocityCmdMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="32" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="44" />
+            </Field>
+          </Value>
+        </Field>
+        <Field name="velCmd" xsi:type="array" type="VelocityCmd" size="1">
+          <Value key="0">
+            <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+            <Field name="nSeq" xsi:type="array" type="num" size="1" />
+            <Field name="nVelVec" xsi:type="array" type="num" size="6" />
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="velCmdMsg" access="public" xsi:type="array" type="VelocityCmdMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="32" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="velCmd" xsi:type="array" type="VelocityCmd" size="1">
+          <Value key="0">
+            <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+            <Field name="nSeq" xsi:type="array" type="num" size="1" />
+            <Field name="nVelVec" xsi:type="array" type="num" size="6" />
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="writeSingIOMsg" access="public" xsi:type="array" type="WriteSingIOMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="9" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="writeSingleIO" xsi:type="array" type="WriteSingleIO" size="1">
+          <Value key="0">
+            <Field name="bState" xsi:type="array" type="bool" size="1" />
+            <Field name="nModuleId" xsi:type="array" type="num" size="1" />
+            <Field name="nPin" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="writeSingIOAck" access="public" xsi:type="array" type="WriteSingIOMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="9" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="writeSingleIO" xsi:type="array" type="WriteSingleIO" size="1">
+          <Value key="0">
+            <Field name="bState" xsi:type="array" type="bool" size="1" />
+            <Field name="nModuleId" xsi:type="array" type="num" size="1" />
+            <Field name="nPin" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="MotionMode" access="public" xsi:type="array" type="_MotionMode" size="1">
+      <Value key="0">
+        <Field name="INVALID" xsi:type="array" type="num" size="1" />
+        <Field name="JOINT_TRAJ" xsi:type="array" type="num" size="1">
+          <Value key="0" value="1" />
+        </Field>
+        <Field name="VELOCITY_CTRL" xsi:type="array" type="num" size="1">
+          <Value key="0" value="4" />
+        </Field>
+      </Value>
+    </Data>
+    <Data name="MsgType" access="public" xsi:type="array" type="_MsgTypeStaubli" size="1">
+      <Value key="0">
+        <Field name="SET_DRIVE_POWER" xsi:type="array" type="num" size="1" />
+        <Field name="VELOCITY_CFG" xsi:type="array" type="num" size="1">
+          <Value key="0" value="1640" />
+        </Field>
+        <Field name="VELOCITY_CMD" xsi:type="array" type="num" size="1">
+          <Value key="0" value="1641" />
+        </Field>
+        <Field name="READ_IO" xsi:type="array" type="num" size="1" />
+        <Field name="WRITE_SINGLE_IO" xsi:type="array" type="num" size="1" />
+      </Value>
+    </Data>
+    <Data name="VelocityType" access="public" xsi:type="array" type="_VelocityType" size="1">
+      <Value key="0">
+        <Field name="INVALID" xsi:type="array" type="num" size="1" />
+        <Field name="JOINT" xsi:type="array" type="num" size="1">
+          <Value key="0" value="1" />
+        </Field>
+        <Field name="BASE_FRAME" xsi:type="array" type="num" size="1">
+          <Value key="0" value="2" />
+        </Field>
+        <Field name="TOOL_FRAME" xsi:type="array" type="num" size="1">
+          <Value key="0" value="3" />
+        </Field>
+      </Value>
+    </Data>
+    </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/Staubli.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/Staubli.pjx
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.9.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="decodeVelCfg.pgx" />
+    <Program file="decodeVelCmd.pgx" />
+    <Program file="decSetDrvPwrMsg.pgx" />
+    <Program file="decWriSingIOMsg.pgx" />
+    <Program file="encodeVelCfgAck.pgx" />
+    <Program file="encodeVelCmdAck.pgx" />
+    <Program file="encSetDrvPwrAck.pgx" />
+    <Program file="encWriSingIOAck.pgx" />
+    <Program file="init.pgx" />
+    <Program file="initStaubliMsgs.pgx" />
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="Staubli.dtx" />
+  </Database>
+  <Libraries>
+    <Library alias="SimpleMsg" path="Disk://ros_libs/SimpleMessage/SimpleMessage.pjx" />
+  </Libraries>
+  <Types>
+    <Type name="_MotionMode" path="./_MotionMode/MotionMode.pjx" />
+    <Type name="_MsgTypeStaubli" path="./_MsgTypeStaubli/MsgTypeStaubli.pjx" />
+    <Type name="_VelocityType" path="./_VelocityType/VelocityType.pjx" />
+    <Type name="VelocityCmdMsg" path="./VelocityCmdMsg/VelocityCmdMsg.pjx" />
+    <Type name="VelocityCfgMsg" path="./VelocityCfgMsg/VelocityCfgMsg.pjx" />
+    <Type name="SetDrivePwrMsg" path="./SetDrivePwrMsg/SetDrivePwrMsg.pjx" />
+    <Type name="WriteSingIOMsg" path="./WriteSingIOMsg/WriteSingIOMsg.pjx" />
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfg/VelocityCfg.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfg/VelocityCfg.dtx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="nCmdType" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nRefFrameVec" access="public" xsi:type="array" type="num" size="6" />
+    <Data name="nToolVec" access="public" xsi:type="array" type="num" size="6" />
+    <Data name="nAccel" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nVel" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nTransVel" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nRotVel" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfg/VelocityCfg.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfg/VelocityCfg.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="VelocityCfg.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfg/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfg/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfg/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfg/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfgMsg/VelocityCfgMsg.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfgMsg/VelocityCfgMsg.dtx
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="prefix" access="public" xsi:type="array" type="Prefix" size="1">
+      <Value key="0">
+        <Field name="nLength" xsi:type="array" type="num" size="1" />
+        <Field name="nData" xsi:type="array" type="num" size="4" />
+      </Value>
+    </Data>
+    <Data name="header" access="public" xsi:type="array" type="Header" size="1">
+      <Value key="0">
+        <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+        <Field name="nCommType" xsi:type="array" type="num" size="1" />
+        <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+        <Field name="nData" xsi:type="array" type="num" size="12" />
+      </Value>
+    </Data>
+    <Data name="body" access="public" xsi:type="array" type="Body" size="1">
+      <Value key="0">
+        <Field name="nData" xsi:type="array" type="num" size="68" />
+      </Value>
+    </Data>
+    <Data name="velCfg" access="public" xsi:type="array" type="VelocityCfg" size="1">
+      <Value key="0">
+        <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+        <Field name="nRefFrameVec" xsi:type="array" type="num" size="6" />
+        <Field name="nToolVec" xsi:type="array" type="num" size="6" />
+        <Field name="nAccel" xsi:type="array" type="num" size="1" />
+        <Field name="nVel" xsi:type="array" type="num" size="1" />
+        <Field name="nTransVel" xsi:type="array" type="num" size="1" />
+        <Field name="nRotVel" xsi:type="array" type="num" size="1" />
+      </Value>
+    </Data>
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfgMsg/VelocityCfgMsg.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfgMsg/VelocityCfgMsg.pjx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="VelocityCfgMsg.dtx" />
+  </Database>
+  <Libraries />
+  <Types>
+    <Type name="Prefix" path="Disk://ros_libs/Prefix/Prefix.pjx" />
+    <Type name="Header" path="Disk://ros_libs/Header/Header.pjx" />
+    <Type name="Body" path="Disk://ros_libs/Body/Body.pjx" />
+    <Type name="VelocityCfg" path="../VelocityCfg/VelocityCfg.pjx" />
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfgMsg/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfgMsg/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfgMsg/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCfgMsg/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmd/VelocityCmd.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmd/VelocityCmd.dtx
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="nSeq" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nVelVec" access="public" xsi:type="array" type="num" size="6" />
+    <Data name="nCmdType" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmd/VelocityCmd.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmd/VelocityCmd.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="VelocityCmd.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmd/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmd/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmd/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmd/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmdMsg/VelocityCmdMsg.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmdMsg/VelocityCmdMsg.dtx
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="header" access="public" xsi:type="array" type="Header" size="1">
+      <Value key="0">
+        <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+        <Field name="nCommType" xsi:type="array" type="num" size="1" />
+        <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+        <Field name="nData" xsi:type="array" type="num" size="12" />
+      </Value>
+    </Data>
+    <Data name="body" access="public" xsi:type="array" type="Body" size="1">
+      <Value key="0">
+        <Field name="nData" xsi:type="array" type="num" size="32" />
+      </Value>
+    </Data>
+    <Data name="prefix" access="public" xsi:type="array" type="Prefix" size="1">
+      <Value key="0">
+        <Field name="nLength" xsi:type="array" type="num" size="1" />
+        <Field name="nData" xsi:type="array" type="num" size="4" />
+      </Value>
+    </Data>
+    <Data name="velCmd" access="public" xsi:type="array" type="VelocityCmd" size="1">
+      <Value key="0">
+        <Field name="nSeq" xsi:type="array" type="num" size="1" />
+        <Field name="nVelVec" xsi:type="array" type="num" size="6" />
+        <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+      </Value>
+    </Data>
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmdMsg/VelocityCmdMsg.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmdMsg/VelocityCmdMsg.pjx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="VelocityCmdMsg.dtx" />
+  </Database>
+  <Libraries />
+  <Types>
+    <Type name="Body" path="Disk://ros_libs/Body/Body.pjx" />
+    <Type name="Prefix" path="Disk://ros_libs/Prefix/Prefix.pjx" />
+    <Type name="Header" path="Disk://ros_libs/Header/Header.pjx" />
+    <Type name="VelocityCmd" path="../VelocityCmd/VelocityCmd.pjx" />
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmdMsg/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmdMsg/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmdMsg/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/VelocityCmdMsg/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingIOMsg/WriteSingIOMsg.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingIOMsg/WriteSingIOMsg.dtx
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="body" access="public" xsi:type="array" type="Body" size="1">
+      <Value key="0">
+        <Field name="nData" xsi:type="array" type="num" size="9">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="header" access="public" xsi:type="array" type="Header" size="1">
+      <Value key="0">
+        <Field name="nCommType" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="nData" xsi:type="array" type="num" size="12">
+        </Field>
+        <Field name="nMsgType" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="nReplyCode" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="prefix" access="public" xsi:type="array" type="Prefix" size="1">
+      <Value key="0">
+        <Field name="nData" xsi:type="array" type="num" size="4">
+        </Field>
+        <Field name="nLength" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+    <Data name="writeSingleIO" access="public" xsi:type="array" type="WriteSingleIO" size="1">
+      <Value key="0">
+        <Field name="bState" xsi:type="array" type="bool" size="1">
+        </Field>
+        <Field name="nModuleId" xsi:type="array" type="num" size="1">
+        </Field>
+        <Field name="nPin" xsi:type="array" type="num" size="1">
+        </Field>
+      </Value>
+    </Data>
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingIOMsg/WriteSingIOMsg.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingIOMsg/WriteSingIOMsg.pjx
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3" >
+  <Parameters version="s7.9.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="WriteSingIOMsg.dtx" />
+  </Database>
+  <Libraries>
+  </Libraries>
+  <Types>
+    <Type name="Body" path="Disk://ros_libs/Body/Body.pjx" />
+    <Type name="Header" path="Disk://ros_libs/Header/Header.pjx" />
+    <Type name="Prefix" path="Disk://ros_libs/Prefix/Prefix.pjx" />
+    <Type name="WriteSingleIO" path="../WriteSingleIO/WriteSingleIO.pjx" />
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingIOMsg/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingIOMsg/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="start" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingIOMsg/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingIOMsg/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="stop" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingleIO/WriteSingleIO.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingleIO/WriteSingleIO.dtx
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="bState" access="public" xsi:type="array" type="bool" size="1">
+    </Data>
+    <Data name="nModuleId" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+    <Data name="nPin" access="public" xsi:type="array" type="num" size="1">
+    </Data>
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingleIO/WriteSingleIO.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingleIO/WriteSingleIO.pjx
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3" >
+  <Parameters version="s7.9.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="WriteSingleIO.dtx" />
+  </Database>
+  <Libraries>
+  </Libraries>
+  <Types>
+  </Types>
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingleIO/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingleIO/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="start" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingleIO/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/WriteSingleIO/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="stop" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_MotionMode/MotionMode.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_MotionMode/MotionMode.dtx
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="JOINT_TRAJ" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="VELOCITY_CTRL" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="INVALID" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_MotionMode/MotionMode.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_MotionMode/MotionMode.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="MotionMode.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_MotionMode/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_MotionMode/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_MotionMode/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_MotionMode/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_MsgTypeStaubli/MsgTypeStaubli.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_MsgTypeStaubli/MsgTypeStaubli.dtx
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="READ_IO" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="SET_DRIVE_POWER" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="VELOCITY_CFG" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="VELOCITY_CMD" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="WRITE_SINGLE_IO" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_MsgTypeStaubli/MsgTypeStaubli.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_MsgTypeStaubli/MsgTypeStaubli.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="MsgTypeStaubli.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_MsgTypeStaubli/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_MsgTypeStaubli/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_MsgTypeStaubli/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_MsgTypeStaubli/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_VelocityType/VelocityType.dtx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_VelocityType/VelocityType.dtx
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="INVALID" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="JOINT" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="BASE_FRAME" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="TOOL_FRAME" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_VelocityType/VelocityType.pjx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_VelocityType/VelocityType.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="VelocityType.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_VelocityType/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_VelocityType/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/_VelocityType/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/_VelocityType/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/decSetDrvPwrMsg.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/decSetDrvPwrMsg.pgx
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="decSetDrvPwrMsg" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_bFlag" type="bool" use="reference" xsi:type="element" dimensions="1" />
+    </Parameters>
+    <Locals>
+      <Local name="l_nData" type="num" xsi:type="array" size="1" />
+      <Local name="l_nIndex" type="num" xsi:type="array" size="1" />
+      <Local name="l_nRetVal" type="num" xsi:type="array" size="1" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // decode set drive power message body (data)
+
+  // assume failure to decode
+  setDrvPwrAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+
+  // fields:
+  //  setDrvPwrMsg.bDrivePower
+
+
+  // drive power, 1 byte
+  l_nRetVal=fromBinary(setDrvPwrMsg.body.nData,1,"1",l_nData)
+
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+
+  if (l_nData==1)
+    setDrvPwrMsg.bDrivePower=true
+  elseIf (l_nData==0)
+    setDrvPwrMsg.bDrivePower=false
+  else
+    // TODO: debug output
+    x_bFlag=false
+    return
+  endIf
+
+  // decoding successful
+  setDrvPwrAck.header.nReplyCode=SimpleMsg:ReplyCode.SUCCESS
+  x_bFlag=true
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/decWriSingIOMsg.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/decWriSingIOMsg.pgx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="decWriSingIOMsg" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_bFlag" type="bool" use="reference" xsi:type="element" dimensions="1" />
+    </Parameters>
+    <Locals>
+      <Local name="l_nData" type="num" xsi:type="array" size="1" />
+      <Local name="l_nIndex" type="num" xsi:type="array" size="1" />
+      <Local name="l_nRetVal" type="num" xsi:type="array" size="1" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // decode write single IO message body (data)
+
+  // assume failure to decode
+  writeSingIOMsg.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+
+  // fields:
+  //  writeSingIOMsg.writeSingleIO.nModuleId
+  //  writeSingIOMsg.writeSingleIO.nPin
+  //  writeSingIOMsg.writeSingleIO.bState
+
+
+  // module id, 4 bytes
+  l_nRetVal=fromBinary(writeSingIOMsg.body.nData,1,"-4l",writeSingIOMsg.writeSingleIO.nModuleId)
+
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+  
+  // pin, 4 bytes
+  l_nRetVal=fromBinary(writeSingIOMsg.body.nData[4],1,"-4l",writeSingIOMsg.writeSingleIO.nPin)
+
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+  
+  // state, 1 byte
+  l_nRetVal=fromBinary(writeSingIOMsg.body.nData[8],1,"1",l_nData)
+
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+  
+  // convert decoded data to bool
+  if (l_nData==1)
+    writeSingIOMsg.writeSingleIO.bState=true
+  elseIf (l_nData==0)
+    writeSingIOMsg.writeSingleIO.bState=false
+  else
+    logMsg("[ERROR] WriteSingleIO.bState was decoded to: "+toString("",l_nData))
+    x_bFlag=false
+    return
+  endIf
+
+  // decoding successful
+  writeSingIOAck.header.nReplyCode=SimpleMsg:ReplyCode.SUCCESS
+  x_bFlag=true
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/decodeVelCfg.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/decodeVelCfg.pgx
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="decodeVelCfg" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_bFlag" type="bool" use="reference" xsi:type="element" dimensions="1" />
+    </Parameters>
+    <Locals>
+      <Local name="l_nIndex" type="num" xsi:type="array" size="1" />
+      <Local name="l_nRetVal" type="num" xsi:type="array" size="1" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // decode velocity configuration message body (data)
+
+  // assume failure to decode
+  velCfgAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+
+
+  // command type (frame or joint), 4 bytes
+  l_nRetVal=fromBinary(velCfgMsg.body.nData,4,"-4l",velCfgMsg.velCfg.nCmdType)
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+
+  // reference frame vector [6], 24 bytes
+  for l_nIndex=0 to 5 step 1
+    l_nRetVal=fromBinary(velCfgMsg.body.nData[(l_nIndex*4)+4],4,"4.0l",velCfgMsg.velCfg.nRefFrameVec[l_nIndex])
+    if (l_nRetVal!=1)
+      x_bFlag=false
+      return
+    endIf
+  endFor
+
+  // target tool vector [6], 24 bytes
+  for l_nIndex=0 to 5 step 1
+    l_nRetVal=fromBinary(velCfgMsg.body.nData[(l_nIndex*4)+28],4,"4.0l",velCfgMsg.velCfg.nToolVec[l_nIndex])
+    if (l_nRetVal!=1)
+      x_bFlag=false
+      return
+    endIf
+  endFor
+
+  // acceleration, 4 bytes
+  l_nRetVal=fromBinary(velCfgMsg.body.nData[52],4,"4.0l",velCfgMsg.velCfg.nAccel)
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+
+  // velocity, 4 bytes
+  l_nRetVal=fromBinary(velCfgMsg.body.nData[56],4,"4.0l",velCfgMsg.velCfg.nVel)
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+
+  // translational velocity, 4 bytes
+  l_nRetVal=fromBinary(velCfgMsg.body.nData[60],4,"4.0l",velCfgMsg.velCfg.nTransVel)
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+
+  // rotational velocity, 4 bytes
+  l_nRetVal=fromBinary(velCfgMsg.body.nData[64],4,"4.0l",velCfgMsg.velCfg.nRotVel)
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+
+
+  // decoding successful
+  velCfgAck.header.nReplyCode=SimpleMsg:ReplyCode.SUCCESS
+  velCfgAck.velCfg.nCmdType=velCfgMsg.velCfg.nCmdType
+  x_bFlag=true
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/decodeVelCmd.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/decodeVelCmd.pgx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="decodeVelCmd" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_bFlag" type="bool" use="reference" xsi:type="element" dimensions="1" />
+    </Parameters>
+    <Locals>
+      <Local name="l_nIndex" type="num" xsi:type="array" size="1" />
+      <Local name="l_nRetVal" type="num" xsi:type="array" size="1" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // decode velocity command message body (data)
+
+  // assume failure to decode
+  velCmdAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+
+
+  // sequence, 4 bytes
+  l_nRetVal=fromBinary(velCmdMsg.body.nData,4,"-4l",velCmdMsg.velCmd.nSeq)
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+
+  // velocity vector [6], 24 bytes
+  for l_nIndex=0 to 5 step 1
+    l_nRetVal=fromBinary(velCmdMsg.body.nData[(l_nIndex*4)+4],4,"4.0l",velCmdMsg.velCmd.nVelVec[l_nIndex])
+    if (l_nRetVal!=1)
+      x_bFlag=false
+      return
+    endIf
+  endFor
+
+  // velocity command type (see Staubli:VelocityType "enum"), 4 bytes
+  l_nRetVal=fromBinary(velCmdMsg.body.nData[28],4,"4l",velCmdMsg.velCmd.nCmdType)
+  if (l_nRetVal!=1)
+    x_bFlag=false
+    return
+  endIf
+
+
+  // decoding successful
+  velCmdAck.header.nReplyCode=SimpleMsg:ReplyCode.SUCCESS
+  velCmdAck.velCmd.nSeq=velCmdMsg.velCmd.nSeq
+  x_bFlag=true
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/encSetDrvPwrAck.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/encSetDrvPwrAck.pgx
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="encSetDrvPwrAck" access="public" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // encode 'prefix' and 'header'
+  call SimpleMsg:encPrefixHeader(setDrvPwrAck.prefix,setDrvPwrAck.header)
+
+  // encodings of the body field (dummy data) is ignored to save CPU time, since values are all zeros
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/encWriSingIOAck.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/encWriSingIOAck.pgx
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="encWriSingIOAck" access="public" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // encode 'prefix' and 'header'
+  call SimpleMsg:encPrefixHeader(writeSingIOAck.prefix,writeSingIOAck.header)
+
+  // encodings of the body field (dummy data) is ignored to save CPU time, since values are all zeros
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/encodeVelCfgAck.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/encodeVelCfgAck.pgx
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="encodeVelCfgAck" access="public" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // encode 'prefix' and 'header'
+  call SimpleMsg:encPrefixHeader(velCfgAck.prefix,velCfgAck.header)
+
+  // encodings of the body field (dummy data) is ignored to save CPU time, since values are all zeros
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/encodeVelCmdAck.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/encodeVelCmdAck.pgx
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="encodeVelCmdAck" access="public" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // encode 'prefix' and 'header'
+  call SimpleMsg:encPrefixHeader(velCmdAck.prefix,velCmdAck.header)
+
+  // encode 'body' (data)
+  toBinary(velCmdAck.velCmd.nSeq,1,"4l",velCmdAck.body.nData)
+
+  // encodings of the remaining elements (dummy data) is ignored to save CPU time, since values are all zeros
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/init.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/init.pgx
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="init" access="public">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // initialize Staubli specific message IDs for the simple message protocol
+  MsgType.SET_DRIVE_POWER=1610
+  MsgType.READ_IO=1620
+  MsgType.WRITE_SINGLE_IO=1621
+  MsgType.VELOCITY_CFG=1640
+  MsgType.VELOCITY_CMD=1641
+
+  // initialize "enum" values for different motion modes
+  MotionMode.INVALID=0
+  MotionMode.JOINT_TRAJ=1
+  MotionMode.VELOCITY_CTRL=2
+
+  // initialize "enum" values for the three different types of velocity init functions $velJoint, $velFrame, $velTool
+  VelocityType.INVALID=0
+  VelocityType.JOINT=1
+  VelocityType.BASE_FRAME=2
+  VelocityType.TOOL_FRAME=3
+
+  // initialize Staubli specific messages (MUST be called last because of the dependency on the values above)
+  call initStaubliMsgs()
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/initStaubliMsgs.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/initStaubliMsgs.pgx
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="initStaubliMsgs">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // initialize Staubli specific messages (outgoing)
+
+
+  // Set drive power message:
+  // prefix length = 12 + 1 = 13
+  setDrvPwrAck.prefix.nLength=13
+  setDrvPwrAck.header.nMsgType=MsgType.SET_DRIVE_POWER
+  setDrvPwrAck.header.nCommType=SimpleMsg:CommType.SERVICE_REPLY
+  setDrvPwrAck.header.nReplyCode=SimpleMsg:ReplyCode.INVALID
+  // body (data) assumed to be initialized to zero
+
+
+  // Write single IO message:
+  // prefix length = 12 + 9 = 21
+  writeSingIOAck.prefix.nLength=21
+  writeSingIOAck.header.nMsgType=MsgType.WRITE_SINGLE_IO
+  writeSingIOAck.header.nCommType=SimpleMsg:CommType.SERVICE_REPLY
+  writeSingIOAck.header.nReplyCode=SimpleMsg:ReplyCode.INVALID
+  // body (data) assumed to be initialized to zero
+
+
+  // Velocity mode configuration message:
+  // prefix length = 12 + 68 = 80
+  velCfgAck.prefix.nLength=80
+  velCfgAck.header.nMsgType=MsgType.VELOCITY_CFG
+  velCfgAck.header.nCommType=SimpleMsg:CommType.SERVICE_REPLY
+  velCfgAck.header.nReplyCode=SimpleMsg:ReplyCode.INVALID
+  // body (data) assumed to be initialized to zero
+
+
+  // Velocity command message:
+  // prefix length = 12 + 32 = 44
+  velCmdAck.prefix.nLength=44
+  velCmdAck.header.nMsgType=MsgType.VELOCITY_CMD
+  velCmdAck.header.nCommType=SimpleMsg:CommType.SERVICE_REPLY
+  velCmdAck.header.nReplyCode=SimpleMsg:ReplyCode.INVALID
+  // body (data) assumed to be initialized to zero
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="start" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/Staubli/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/Staubli/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="stop" access="private" >
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/_MsgRecvState/MsgRecvState.dtx
+++ b/staubli_val3_driver/val3/ros_libs/_MsgRecvState/MsgRecvState.dtx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
+  <Datas>
+    <Data name="RECEIVE_HEADER" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="DECODE_HEADER" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="RECEIVE_BODY" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="DECODE_BODY" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="PUSH_MOTION" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="HANDLE_REQUEST" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="SEND_ACK" access="public" xsi:type="array" type="num" size="1" />
+  </Datas>
+</Database>

--- a/staubli_val3_driver/val3/ros_libs/_MsgRecvState/MsgRecvState.pjx
+++ b/staubli_val3_driver/val3/ros_libs/_MsgRecvState/MsgRecvState.pjx
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
+  <Parameters version="s7.8.1" stackSize="5000" millimeterUnit="true" />
+  <Programs>
+    <Program file="start.pgx" />
+    <Program file="stop.pgx" />
+  </Programs>
+  <Database>
+    <Data file="MsgRecvState.dtx" />
+  </Database>
+  <Libraries />
+</Project>

--- a/staubli_val3_driver/val3/ros_libs/_MsgRecvState/start.pgx
+++ b/staubli_val3_driver/val3/ros_libs/_MsgRecvState/start.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="start">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_libs/_MsgRecvState/stop.pgx
+++ b/staubli_val3_driver/val3/ros_libs/_MsgRecvState/stop.pgx
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="stop">
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_server/dataReceiver.pgx
+++ b/staubli_val3_driver/val3/ros_server/dataReceiver.pgx
@@ -1,12 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
-  <Program name="dataReceiver" access="public">
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="dataReceiver" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_sSocket" type="sio" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nConnFlag" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_msg" type="RosSimpleMsg" use="reference" xsi:type="element" dimensions="1" />
+    </Parameters>
     <Locals>
-      <Local name="l_nStartTime" type="num" xsi:type="array" size="1" />
       <Local name="l_nMsgRecvState" type="num" xsi:type="array" size="1" />
+      <Local name="l_nStartTime" type="num" xsi:type="array" size="1" />
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -21,15 +27,15 @@
   // limitations under the License.
 
 
-
   // state machine at initial state
-  // 0: receive header
-  // 1: decode header
-  // 2: receive body
-  // 3: decode body
-  // 4: push motion into buffer
-  // 5: send ACK
-  l_nMsgRecvState=0
+  // 0: RECEIVE_HEADER
+  // 1: DECODE_HEADER
+  // 2: RECEIVE_BODY
+  // 3: DECODE_BODY
+  // 4: PUSH_MOTION
+  // 5: HANDLE_REQUEST
+  // 6: SEND_ACK
+  l_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
 
   while (true)
     // usually for state machines a switch-case statement is a neat implementation
@@ -40,38 +46,90 @@
     // The desirable behaviour is to receive and decode a full message, push motion
     // into buffer and then send ACK to client WITHIN ONE ITERATION of while(),
     // hence the if statement sequence below
-    l_nStartTime = clock()
-    if (l_nMsgRecvState==0)
-      call recvMsgHeader(l_nMsgRecvState)
+    l_nStartTime=clock()
+
+    if (l_nMsgRecvState == MsgRecvState.RECEIVE_HEADER)
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=0)
+        call printDebug("dataReceiver: recvMsgHeader",true)
+      endIf
+      //endregion
+
+      call recvMsgHeader(x_sSocket,x_nConnFlag,x_msg,l_nMsgRecvState)
     endIf
-    nHeaderTime = clock() - l_nStartTime
-    if (l_nMsgRecvState==1)
-      call decodeMsgHeader(l_nMsgRecvState)
+
+    nHeaderTime=clock()-l_nStartTime
+
+    if (l_nMsgRecvState == MsgRecvState.DECODE_HEADER)
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=1)
+        call printDebug("dataReceiver: decodeMsgHeader",true)
+      endIf
+      //endregion
+
+      call decodeMsgHeader(x_msg,l_nMsgRecvState)
     endIf
-    if (l_nMsgRecvState==2)
-      call recvMsgBody(l_nMsgRecvState)
+
+    if (l_nMsgRecvState == MsgRecvState.RECEIVE_BODY)
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=2)
+        call printDebug("dataReceiver: recvMsgBody",true)
+      endIf
+      //endregion
+
+      call recvMsgBody(x_sSocket,x_nConnFlag,x_msg,l_nMsgRecvState)
     endIf
-    if (l_nMsgRecvState==3)
-      call decodeMsgBody(l_nMsgRecvState)
+
+    if (l_nMsgRecvState == MsgRecvState.DECODE_BODY)
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=3)
+        call printDebug("dataReceiver: decodeMsgBody",true)
+      endIf
+      //endregion
+
+      call decodeMsgBody(x_msg,l_nMsgRecvState)
     endIf
-    if (l_nMsgRecvState==4)
-      call pushMotion(l_nMsgRecvState)
+
+    if (l_nMsgRecvState == MsgRecvState.PUSH_MOTION)
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=4)
+        call printDebug("dataReceiver: pushMotion",true)
+      endIf
+      //endregion
+
+      call pushMotion(x_msg,l_nMsgRecvState)
     endIf
-    if (l_nMsgRecvState==5)
-      call encodeAck()
-      call sendAck(l_nMsgRecvState)
+
+    if (l_nMsgRecvState == MsgRecvState.HANDLE_REQUEST)
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=4)
+        call printDebug("dataReceiver: handleRequest",true)
+      endIf
+      //endregion
+
+      call handleRequest(x_msg,l_nMsgRecvState)
     endIf
-    nElapsedTime = clock() - l_nStartTime - nHeaderTime
-    
+
+    if (l_nMsgRecvState == MsgRecvState.SEND_ACK)
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=5)
+        call printDebug("dataReceiver: encode/sendAck",true)
+      endIf
+      //endregion
+
+      call encodeAck(x_msg)
+      call sendAck(x_sSocket,x_nConnFlag,x_msg,l_nMsgRecvState)
+    endIf
+
+    nElapsedTime=clock()-l_nStartTime-nHeaderTime
+
     // assert state machine is working OK
-    if (l_nMsgRecvState<0 or l_nMsgRecvState>5)
+    if (l_nMsgRecvState<0 or l_nMsgRecvState>6)
       popUpMsg("Data reception state machine error")
     endIf
 
     // sequence task
     delay(0)
-
-
   endWhile
 end]]></Code>
   </Program>

--- a/staubli_val3_driver/val3/ros_server/dataStreamer.pgx
+++ b/staubli_val3_driver/val3/ros_server/dataStreamer.pgx
@@ -3,10 +3,12 @@
   <Program name="dataStreamer" access="public">
     <Locals>
       <Local name="l_nThrottle" type="num" xsi:type="array" size="1" />
-      <Local name="l_jCurrPose" type="jointRx" xsi:type="array" size="1" />
+      <Local name="l_nTime" type="num" xsi:type="array" size="1" />
+      <Local name="l_nJntSpeed" type="num" xsi:type="array" size="6" />
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -25,27 +27,47 @@
   l_nThrottle = 0
   while (true)
     // only attempt to send data if flag indicates that connection is established
-    if (nOutConnFlag == 1)
-      // fetch current joint positions
-      l_jCurrPose=herej()
-      // encode and send ROS simple_message ID 10: joint state
-      call encodeJState(l_jCurrPose)
-      call sendRosMsg(siTcpIpFbk, rosJointMsg.prefix, rosJointMsg.header, rosJointMsg.body, nOutConnFlag)
-      
-      // send Robot Status messages 5 times slower than Joint State
-      if (l_nThrottle == 5)
+    if (nConnFlagState == 1)
+      // fetch current joint feedback data
+      l_nTime = clock()
+      jPosition = herej()
+      $getJntSpeedCmd(l_nJntSpeed)
+      jSpeed.j1 = l_nJntSpeed[0]
+      jSpeed.j2 = l_nJntSpeed[1]
+      jSpeed.j3 = l_nJntSpeed[2]
+      jSpeed.j4 = l_nJntSpeed[3]
+      jSpeed.j5 = l_nJntSpeed[4]
+      jSpeed.j6 = l_nJntSpeed[5]
+
+      // init joint feedback message, valid fields: ( time[0x01] | pos[0x02] | vel[0x04] )
+      rosJointFbkMsg.jointFeedback.nRobotId = 0
+      rosJointFbkMsg.jointFeedback.nValidFields = 7
+      rosJointFbkMsg.jointFeedback.nTime = l_nTime
+
+      // encode and send ROS simple_message ID 15: joint feedback
+      call encodeJFeedback(l_nTime, jPosition, jSpeed)
+      call sendRosMsg(siTcpIpState, rosJointFbkMsg.prefix, rosJointFbkMsg.header, rosJointFbkMsg.body, nConnFlagState)
+
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel==8)
+        call printDebug("dataStreamer: Sent fbk msg", true)
+      endIf
+      //endregion
+
+      // send Robot Status messages 20 times slower than Joint State
+      if (l_nThrottle == 20)
         // fetch robot status
         call fetchStatus()
         // encode and send ROS simple_message ID 13: robot status
         call encodeStatus()
-        call sendRosMsg(siTcpIpFbk, rosStatusMsg.prefix, rosStatusMsg.header, rosStatusMsg.body, nOutConnFlag)
+        call sendRosMsg(siTcpIpState, rosStatusMsg.prefix, rosStatusMsg.header, rosStatusMsg.body, nConnFlagState)
         l_nThrottle = 0
       endIf
       l_nThrottle = l_nThrottle + 1
     else
       delay(0.1)
     endIf
-    
+
     // sequence task
     delay(0)
   endWhile

--- a/staubli_val3_driver/val3/ros_server/decodeMsgBody.pgx
+++ b/staubli_val3_driver/val3/ros_server/decodeMsgBody.pgx
@@ -2,6 +2,7 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="decodeMsgBody" access="public">
     <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
+      <Parameter name="x_msg" type="RosSimpleMsg" xsi:type="element" use="reference" />
       <Parameter name="x_nMsgRecvState" type="num" xsi:type="element" use="reference" />
     </Parameters>
     <Locals>
@@ -9,6 +10,7 @@
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -23,43 +25,105 @@
   // limitations under the License.
 
 
-
+  // assume failure to decode
   l_bFlag=false
 
-  switch rosGenericMsg.header.nMsgType
-    case 11
+  //region @decode -- call specific decode function
+  switch x_msg.header.nMsgType
+    case SimpleMsg:MsgType.JOINT_TRAJ_PT
       call decTrajPt(l_bFlag)
     break
-    case 14
+    case SimpleMsg:MsgType.JOINT_TRAJ_PT_F
       call decTrajPtFull(l_bFlag)
     break
+    // Staubli specific
+    case Staubli:MsgType.SET_DRIVE_POWER
+      call Staubli:decSetDrvPwrMsg(l_bFlag)
+    break
+    case Staubli:MsgType.WRITE_SINGLE_IO
+      call Staubli:decWriSingIOMsg(l_bFlag)
+    break
+    case Staubli:MsgType.VELOCITY_CFG
+      call Staubli:decodeVelCfg(l_bFlag)
+    break
+    case Staubli:MsgType.VELOCITY_CMD
+      call Staubli:decodeVelCmd(l_bFlag)
+    break
     default
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=3)
+        call printDebug("ERROR: unknown msg type ("+toString("",x_msg.header.nMsgType)+")",false)
+        call printDebug("       could not decode message",false)
+      endIf
+      //endregion
     break
   endSwitch
+  //endregion
 
+  //region @check_success -- check whether decoding was successful and move on to the next state
   if (l_bFlag == true)
-    // move on to state 4: push motion into buffer
-    x_nMsgRecvState=4
+    switch x_msg.header.nMsgType
+      case SimpleMsg:MsgType.JOINT_TRAJ_PT,SimpleMsg:MsgType.JOINT_TRAJ_PT_F,Staubli:MsgType.VELOCITY_CFG,Staubli:MsgType.VELOCITY_CMD
+        // move on to state: push motion into buffer
+        x_nMsgRecvState = MsgRecvState.PUSH_MOTION
+      break
+      case Staubli:MsgType.SET_DRIVE_POWER, Staubli:MsgType.WRITE_SINGLE_IO
+        // move on to state: handle system/io request
+        x_nMsgRecvState = MsgRecvState.HANDLE_REQUEST
+      break
+    endSwitch
+
+    //region @DEBUG
+    if (bDebugMode and nDebugLevel<=3)
+      call printDebug("INFO: decoding successful",false)
+    endIf
+    //endregion
   else
     // error whilst decoding msg body...
-    if (rosGenericMsg.header.nCommType==2)
-      switch rosGenericMsg.header.nMsgType
-        case 11
-          rosTrajPtAck.header.nReplyCode=2
+    if (x_msg.header.nCommType==SimpleMsg:CommType.SERVICE_REQUEST)
+      // set reply code if comm type is request
+      switch x_msg.header.nMsgType
+        case SimpleMsg:MsgType.JOINT_TRAJ_PT
+          rosTrajPtAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
         break
-        case 14
-          rosTrajPtFAck.header.nReplyCode=2
+        case SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+          rosTrajPtFAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        // Staubli specific
+        case Staubli:MsgType.SET_DRIVE_POWER
+          Staubli:setDrvPwrAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        case Staubli:MsgType.WRITE_SINGLE_IO
+          Staubli:writeSingIOAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        case Staubli:MsgType.VELOCITY_CFG
+          Staubli:velCfgAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        case Staubli:MsgType.VELOCITY_CMD
+          Staubli:velCmdAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
         break
         default
+          //region @DEBUG
+          if (bDebugMode and nDebugLevel<=3)
+            call printDebug("ERROR: unknown msg type ("+toString("",x_msg.header.nMsgType)+")",false)
+            call printDebug("       could not set reply code",false)
+          endIf
+          //endregion
         break
       endSwitch
-      // jump to state 5: sendAck()
-      x_nMsgRecvState=5
+      // jump to state 6: sendAck()
+      x_nMsgRecvState = MsgRecvState.SEND_ACK
     else
       // reset state machine, since no ACK is required
-      x_nMsgRecvState=0
+      x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
     endIf
+    //region @DEBUG
+    if (bDebugMode and nDebugLevel<=3)
+      call printDebug("ERROR: decoding not successful",false)
+    endIf
+    //endregion
   endIf
+  //endregion
 end]]></Code>
   </Program>
 </Programs>

--- a/staubli_val3_driver/val3/ros_server/decodeMsgHeader.pgx
+++ b/staubli_val3_driver/val3/ros_server/decodeMsgHeader.pgx
@@ -2,13 +2,15 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="decodeMsgHeader" access="public">
     <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
-      <Parameter name="x_nMsgRecvState" type="num" xsi:type="element" use="reference" />
+      <Parameter name="x_msg" type="RosSimpleMsg" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nMsgRecvState" type="num" use="reference" xsi:type="element" dimensions="1" />
     </Parameters>
     <Locals>
       <Local name="l_nRetVal" type="num" xsi:type="array" size="1" />
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -25,34 +27,43 @@
 
 
   // decode message into generic message first  
-  l_nRetVal=fromBinary(rosGenericMsg.prefix.nData,4,"-4l",rosGenericMsg.prefix.nLength)
+  l_nRetVal=fromBinary(x_msg.prefix.nData,4,"-4l",x_msg.prefix.nLength)
   if (l_nRetVal!=1)
     // error decoding prefix, reset state machine
-    x_nMsgRecvState=0
+    x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
     return
   endIf
-  l_nRetVal=fromBinary(rosGenericMsg.header.nData,4,"-4l",rosGenericMsg.header.nMsgType)
+  l_nRetVal=fromBinary(x_msg.header.nData,4,"-4l",x_msg.header.nMsgType)
   if (l_nRetVal!=1)
     // error decoding header (msg type), reset state machine
-    x_nMsgRecvState=0
+    x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
     return
   endIf
-  l_nRetVal=fromBinary(rosGenericMsg.header.nData[4],4,"-4l",rosGenericMsg.header.nCommType)
+  l_nRetVal=fromBinary(x_msg.header.nData[4],4,"-4l",x_msg.header.nCommType)
   if (l_nRetVal!=1)
     // error decoding header (comm type), reset state machine
-    x_nMsgRecvState=0
+    x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
     return
   endIf
-  l_nRetVal=fromBinary(rosGenericMsg.header.nData[8],4,"-4l",rosGenericMsg.header.nReplyCode)
+  l_nRetVal=fromBinary(x_msg.header.nData[8],4,"-4l",x_msg.header.nReplyCode)
   if (l_nRetVal!=1)
     // error decoding header (reply code), reset state machine
-    x_nMsgRecvState=0
+    x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
     return
   endIf
 
   // no errors detected whilst decoding prefix and header
   // move on to state 2: receive msg body
-  x_nMsgRecvState=2
+  x_nMsgRecvState = MsgRecvState.RECEIVE_BODY
+
+  // debug
+  if (bDebugMode and nDebugLevel<=1)
+    call printDebug("decodeMsgHeader: successful",true)
+    call printDebug("Prefix    :"+toString("",x_msg.prefix.nLength),false)
+    call printDebug("MsgType   :"+toString("",x_msg.header.nMsgType),false)
+    call printDebug("CommType  :"+toString("",x_msg.header.nCommType),false)
+    call printDebug("ReplyType :"+toString("",x_msg.header.nReplyCode),false)
+  endIf
 end]]></Code>
   </Program>
 </Programs>

--- a/staubli_val3_driver/val3/ros_server/encodeAck.pgx
+++ b/staubli_val3_driver/val3/ros_server/encodeAck.pgx
@@ -1,8 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
   <Program name="encodeAck" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
+      <Parameter name="x_msg" type="RosSimpleMsg" xsi:type="element" use="reference" />
+    </Parameters>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -18,14 +22,40 @@
 
 
 
-  switch rosGenericMsg.header.nMsgType
-    case 11
+  switch x_msg.header.nMsgType
+
+    case SimpleMsg:MsgType.JOINT_TRAJ_PT
       call encTrajPtAck()
     break
-    case 14
+
+    case SimpleMsg:MsgType.JOINT_TRAJ_PT_F
       call encTrajPtFAck()
     break
+
+    // Staubli specific
+    case Staubli:MsgType.SET_DRIVE_POWER
+      call Staubli:encSetDrvPwrAck()
+    break
+
+    case Staubli:MsgType.WRITE_SINGLE_IO
+      call Staubli:encWriSingIOAck()
+    break
+
+    case Staubli:MsgType.VELOCITY_CFG
+      call Staubli:encodeVelCfgAck()
+    break
+
+    case Staubli:MsgType.VELOCITY_CMD
+      call Staubli:encodeVelCmdAck()
+    break
+
     default
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=5)
+        call printDebug("encodeAck: switch (msgType)",true)
+        call printDebug("ERROR: unknown msg type",false)
+      endIf
+      //endregion
     break
   endSwitch
 end]]></Code>

--- a/staubli_val3_driver/val3/ros_server/encodeJFeedback.pgx
+++ b/staubli_val3_driver/val3/ros_server/encodeJFeedback.pgx
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="encodeJFeedback">
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
+      <Parameter name="x_nTime" type="num" xsi:type="element" />
+      <Parameter name="x_jPosition" type="jointRx" xsi:type="element" />
+      <Parameter name="x_jVelocity" type="jointRx" xsi:type="element" />
+    </Parameters>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // encode 'prefix' and 'header'
+  call encPrefixHeader(rosJointFbkMsg.prefix, rosJointFbkMsg.header)
+
+  // encode 'robot_id' variable of body message (data)
+  toBinary(rosJointFbkMsg.jointFeedback.nRobotId, 1, "-4l", rosJointFbkMsg.body.nData)
+
+  // encode 'valid_fields' variable of body message (data)
+  toBinary(rosJointFbkMsg.jointFeedback.nValidFields, 1, "-4l", rosJointFbkMsg.body.nData[4])
+
+  // encode 'time' variable of body message (data)
+  toBinary(rosJointFbkMsg.jointFeedback.nTime, 1, "-4l", rosJointFbkMsg.body.nData[8])
+
+  call toJointArrayRad(x_jPosition, rosJointFbkMsg.jointFeedback.nPositions)
+
+  // encode 10 values representing joint positions [10]
+  toBinary(rosJointFbkMsg.jointFeedback.nPositions, 10, "4.0l", rosJointFbkMsg.body.nData[12])
+
+  call toJointArrayRad(x_jVelocity, rosJointFbkMsg.jointFeedback.nVelocities)
+
+  // encode 10 values representing joint velocities [10]
+  toBinary(rosJointFbkMsg.jointFeedback.nVelocities, 10, "4.0l", rosJointFbkMsg.body.nData[52])
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_server/fetchStatus.pgx
+++ b/staubli_val3_driver/val3/ros_server/fetchStatus.pgx
@@ -3,6 +3,7 @@
   <Program name="fetchStatus" access="public">
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -35,22 +36,22 @@
   endIf
 
   // error_code
-  if (taskStatus(sMotionTaskName) > 1)
-    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sMotionTaskName)
-  elseIf (taskStatus(sTrajPtTaskName) > 1)
-    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sTrajPtTaskName)
-  elseIf (taskStatus(sStreamTaskName) > 1)
-    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sStreamTaskName)
-  elseIf (taskStatus(sHtbtTaskName) > 1)
-    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sHtbtTaskName)
-  elseIf (taskStatus(sScreenTaskName) > 1)
-    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sScreenTaskName)
+  if (taskStatus(sMotionTask) > 1)
+    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sMotionTask)
+  elseIf (taskStatus(sMotionRecvTask) > 1)
+    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sMotionRecvTask)
+  elseIf (taskStatus(sStreamerTask) > 1)
+    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sStreamerTask)
+  elseIf (taskStatus(sHeartbeatTask) > 1)
+    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sHeartbeatTask)
+  elseIf (taskStatus(sScreenTask) > 1)
+    rosStatusMsg.robotStatus.nErrorCode = taskStatus(sScreenTask)
   else
     rosStatusMsg.robotStatus.nErrorCode = 0
   endIf
 
   // in_error
-  if (taskStatus(sTrajPtTaskName) == 1 and taskStatus(sMotionTaskName) == 1 and taskStatus(sStreamTaskName) == 1 and taskStatus(sScreenTaskName) == 1 and taskStatus(sHtbtTaskName) == 1)
+  if (taskStatus(sMotionRecvTask) == 1 and taskStatus(sMotionTask) == 1 and taskStatus(sStreamerTask) == 1 and taskStatus(sScreenTask) == 1 and taskStatus(sHeartbeatTask) == 1)
     rosStatusMsg.robotStatus.nInError = 0
   else
     rosStatusMsg.robotStatus.nInError = 1
@@ -80,7 +81,7 @@
   // drives must be powered and e-stop must be off
   // and dataReceiver and motionControl tasks must be
   // running normally
-  if (isPowered() == true and esStatus() == 0 and taskStatus(sTrajPtTaskName) == 1 and taskStatus(sMotionTaskName) == 1)
+  if (isPowered() == true and esStatus() == 0 and taskStatus(sMotionRecvTask) == 1 and taskStatus(sMotionTask) == 1)
     rosStatusMsg.robotStatus.nMotionPossible=1
   else
     rosStatusMsg.robotStatus.nMotionPossible=0

--- a/staubli_val3_driver/val3/ros_server/handleRequest.pgx
+++ b/staubli_val3_driver/val3/ros_server/handleRequest.pgx
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
+  <Program name="handleRequest" access="public">
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
+      <Parameter name="x_msg" type="RosSimpleMsg" xsi:type="element" use="reference" />
+      <Parameter name="x_nMsgRecvState" type="num" xsi:type="element" use="reference" />
+    </Parameters>
+    <Locals>
+      <Local name="l_bOk" type="bool" xsi:type="array" size="1" />
+      <Local name="l_nModuleId" type="num" xsi:type="array" size="1" />
+      <Local name="l_nPin" type="num" xsi:type="array" size="1" />
+      <Local name="l_bState" type="bool" xsi:type="array" size="1" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // assume success to push motion
+  l_bOk=true
+
+  // handle request
+  switch x_msg.header.nMsgType
+    case Staubli:MsgType.SET_DRIVE_POWER
+      if (Staubli:setDrvPwrMsg.bDrivePower==true and isPowered()==false)
+        enablePower()
+      elseIf (Staubli:setDrvPwrMsg.bDrivePower==false and isPowered()==true)
+        disablePower()
+      else
+        // nothing to do
+      endIf
+    break
+    case Staubli:MsgType.WRITE_SINGLE_IO
+      l_nModuleId=Staubli:writeSingIOMsg.writeSingleIO.nModuleId
+      l_nPin=Staubli:writeSingIOMsg.writeSingleIO.nPin
+      l_bState=Staubli:writeSingIOMsg.writeSingleIO.bState
+      call IO:writeSingle(l_nModuleId,l_nPin,l_bState,l_bOk)
+    break
+    // unknown message type
+    default
+      l_bOk=false
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=4)
+        call printDebug("ERROR: unknown msg type ("+toString("",x_msg.header.nMsgType)+")",false)
+      endIf
+      //endregion
+    break
+  endSwitch
+
+  //region @check_success -- check whether handling request was successful 
+  if (l_bOk)
+    //region @DEBUG
+    if (bDebugMode and nDebugLevel<=4)
+      call printDebug("INFO: handling request successful",false)
+    endIf
+    //endregion
+  else
+    // could not handle request
+    // thus ACK should flag FAILURE, but only if comm type is request
+    if (x_msg.header.nCommType==SimpleMsg:CommType.SERVICE_REQUEST)
+      switch x_msg.header.nMsgType
+        case Staubli:MsgType.SET_DRIVE_POWER
+          Staubli:setDrvPwrAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        case Staubli:MsgType.WRITE_SINGLE_IO
+          Staubli:writeSingIOAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        default
+        break
+      endSwitch
+    endIf
+    //region @DEBUG
+    if (bDebugMode and nDebugLevel<=4)
+      call printDebug("ERROR: handling request not successful",false)
+    endIf
+    //endregion
+  endIf
+  //endregion
+
+  //region @check_reply -- check whether service reply (ACK) should be sent
+  if (x_msg.header.nCommType==SimpleMsg:CommType.SERVICE_REQUEST)
+    // comm type request requires ACK
+    x_nMsgRecvState = MsgRecvState.SEND_ACK
+  else
+    // other comm types (e.g., topic) does not require ACK, hence skip state
+    x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
+  endIf
+  //endregion
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_server/initParams.pgx
+++ b/staubli_val3_driver/val3/ros_server/initParams.pgx
@@ -6,6 +6,7 @@
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -19,16 +20,32 @@
   // See the License for the specific language governing permissions and
   // limitations under the License.
 
+  MsgRecvState.RECEIVE_HEADER=0
+  MsgRecvState.DECODE_HEADER=1
+  MsgRecvState.RECEIVE_BODY=2
+  MsgRecvState.DECODE_BODY=3
+  MsgRecvState.PUSH_MOTION=4
+  MsgRecvState.HANDLE_REQUEST=5
+  MsgRecvState.SEND_ACK=6
 
+  l_nRetVal=sioCtrl(siTcpIpIO,"timeout",-1)
+  if (l_nRetVal!=0)
+    popUpMsg("Error while setting 'IO' socket timeout")
+  endIf
 
   l_nRetVal=sioCtrl(siTcpIpMotion,"timeout",-1)
   if (l_nRetVal!=0)
-    popUpMsg("Error while setting consumer timeout")
+    popUpMsg("Error while setting 'Motion' socket timeout")
   endIf
 
-  l_nRetVal=sioCtrl(siTcpIpFbk,"timeout",-1)
+  l_nRetVal=sioCtrl(siTcpIpState,"timeout",-1)
   if (l_nRetVal!=0)
-    popUpMsg("Error while setting producer timeout")
+    popUpMsg("Error while setting 'State' socket timeout")
+  endIf
+
+  l_nRetVal=sioCtrl(siTcpIpSystem,"timeout",-1)
+  if (l_nRetVal!=0)
+    popUpMsg("Error while setting 'System' socket timeout")
   endIf
 end]]></Code>
   </Program>

--- a/staubli_val3_driver/val3/ros_server/initRosMsgs.pgx
+++ b/staubli_val3_driver/val3/ros_server/initRosMsgs.pgx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
-  <Program name="setupRosMsgs" access="public">
+  <Program name="initRosMsgs" access="public">
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
   //

--- a/staubli_val3_driver/val3/ros_server/motionControl.pgx
+++ b/staubli_val3_driver/val3/ros_server/motionControl.pgx
@@ -2,15 +2,17 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="motionControl" access="public">
     <Locals>
-      <Local name="l_mTrajPt" type="MotionCmd" xsi:type="array" size="1" />
       <Local name="l_bFlag" type="bool" xsi:type="array" size="1" />
-      <Local name="l_motion" type="MotionCmd" xsi:type="array" size="1" />
-      <Local name="l_nTime" type="num" xsi:type="array" size="1" />
       <Local name="l_bStopAndClean" type="bool" xsi:type="array" size="1" />
+      <Local name="l_jTmp" type="joint" xsi:type="array" size="1" />
+      <Local name="l_mTrajPt" type="MotionCmd" xsi:type="array" size="1" />
+      <Local name="l_motion" type="MotionCmd" xsi:type="array" size="1" />
       <Local name="l_nElems" type="num" xsi:type="array" size="1" />
+      <Local name="l_nTime" type="num" xsi:type="array" size="1" />
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -30,8 +32,8 @@
 
   while (true)
     // check connection status, and whether to stop motion
-    if (nInConnFlag == 1 and nOutConnFlag == 1 and bStopNow == false)
-      
+    if (nConnFlagMotion == 1 and nConnFlagState == 1 and bStopNow == false)
+
       // process trajectory point from trajectory buffer
       call libQueueFuncs:getNumElems(qTrajPtBuffer, l_nElems)
       if (l_nElems > 0)
@@ -41,7 +43,7 @@
           call libQueueFuncs:push(qMoveBuffer,l_mTrajPt,l_bFlag)
         endIf
       endIf
-      
+
       // process motion command from move buffer
       // @TODO move buffer should have elements previously interpolated to ensure they are 4 ms apart
       call libQueueFuncs:getNumElems(qMoveBuffer, l_nElems)
@@ -57,21 +59,41 @@
           // always be a delay in the data coming out of herej() and the actual pose of the robot.
           // @TODO potentially set move id according to sequence value
           nMoveId = movej(l_motion.jJointRx, tTool, l_motion.mDesc)
+
+          if (bDebugMode and nDebugLevel<=6)
+            l_jTmp=l_motion.jJointRx
+            call printDebug("motionControl: movej() = "+toString("",nMoveId),true)
+            call printDebug("Joint:  "+toString("",l_jTmp.j1)+" "+toString("",l_jTmp.j2)+" "+toString("",l_jTmp.j3)+" "+toString("",l_jTmp.j4)+" "+toString("",l_jTmp.j5)+" "+toString("",l_jTmp.j6),false)
+            call printDebug("vel  :  "+toString("5",l_motion.mDesc.vel),false)
+            call printDebug("tvel :  "+toString("5",l_motion.mDesc.tvel)+"  rvel :  "+toString("5",l_motion.mDesc.rvel),false)
+            call printDebug("accel:  "+toString("5",l_motion.mDesc.accel)+"  decel:  "+toString("5",l_motion.mDesc.decel),false)
+          endIf
         endIf
       endIf
     else
       // stop immediately -- resetMotion() also resets moveId
       resetMotion()
+      nMoveId = 0
+
       // clear buffers
       call libQueueFuncs:clear(qTrajPtBuffer)
       call libQueueFuncs:clear(qMoveBuffer)
-      bStopNow = false
-      
+
       // debug
       nPtsPopped = 0
       nMovePts = 0
+
+      // debug
+      if (bDebugMode and nDebugLevel==6)
+        call printDebug("motionControl: resetMotion()",true)
+        call printDebug("bStopNow: "+toString("",sel(bStopNow,1,0))+" inConn: "+toString("",nConnFlagMotion)+" outConn: "+toString("",nConnFlagState),false)
+      endIf
+
+      // reset stop flag
+      bStopNow = false
     endIf
-      
+
+    // store actual move id (progress)
     nMotionProgress = getMoveId()
 
     // sequence task

--- a/staubli_val3_driver/val3/ros_server/motionCtrlVel.pgx
+++ b/staubli_val3_driver/val3/ros_server/motionCtrlVel.pgx
@@ -1,0 +1,115 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="motionCtrlVel" access="private" >
+    <Locals>
+      <Local name="l_bVelReady" type="bool" xsi:type="array" size="1" />
+      <Local name="l_nIndex" type="num" xsi:type="array" size="1" />
+      <Local name="l_nResult" type="num" xsi:type="array" size="1" />
+      <Local name="l_nVelCmd" type="num" xsi:type="array" size="6" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  l_bVelReady=false
+
+  while (true)
+    // check connection status and whether to stop motion
+    if (nConnFlagMotion==1 and nConnFlagState==1 and bStopNow==false)
+      if (l_bVelReady==false)
+		// start velocity mode according to configured velocity command type
+        switch motionCfgVel.nCmdType
+          case Staubli:VelocityType.JOINT
+            $velJoint(motionCfgVel.tTool, motionCfgVel.mMaxSpeed)
+            l_bVelReady=true
+			if (bDebugMode and nDebugLevel==6)
+				call printDebug("motionCtrlVel: $velJoint()",true)
+			endIf
+          break
+          case Staubli:VelocityType.BASE_FRAME
+            l_nResult=$velFrame(motionCfgVel.fReference, motionCfgVel.tTool, motionCfgVel.mMaxSpeed)
+            if (l_nResult==0)
+              l_bVelReady=true
+            endIf
+			if (bDebugMode and nDebugLevel==6)
+				call printDebug("motionCtrlVel: $velFrame()",true)
+				call printDebug("Result = "+toString("",l_nResult),false)
+			endIf
+          break
+          case Staubli:VelocityType.TOOL_FRAME
+            l_nResult=$velTool(motionCfgVel.tTool, motionCfgVel.mMaxSpeed)
+            if (l_nResult==0)
+              l_bVelReady=true
+            endIf
+            if (bDebugMode and nDebugLevel==6)
+				call printDebug("motionCtrlVel: $velTool()",true)
+				call printDebug("Result = "+toString("",l_nResult),false)
+			endIf
+          break
+          default
+            popUpMsg("Velocity motion command error: Unknown command type ("+toString("",motionCmdVel.nCmdType)+")")
+          break
+        endSwitch
+      endIf
+
+      if (l_bVelReady)
+		// - copy global velocity command into local variable for $setVelCmd
+		// - store velocity command in other global variable for UI
+		// - reset global velocity command (fail-safe, avoiding repeated execution of old commands)
+        for l_nIndex=0 to 5
+          l_nVelCmd[l_nIndex]=motionCmdVel.nVelCmd[l_nIndex]
+          actMotionCmdVel.nVelCmd[l_nIndex]=motionCmdVel.nVelCmd[l_nIndex]
+          motionCmdVel.nVelCmd[l_nIndex]=0
+        endFor
+
+		// store velocity command type also for displaying in the UI
+		actMotionCmdVel.nCmdType=motionCmdVel.nCmdType
+
+        // execute velocity motion command
+		$setVelCmd(l_nVelCmd)
+
+        if (bDebugMode and nDebugLevel==6)
+          call printDebug("motionCtrlVel: $setVelCmd()",true)
+          call printDebug("l_nVelCmd = "+toString("",l_nVelCmd[0])+" "+toString("",l_nVelCmd[1])+" "+toString("",l_nVelCmd[2])+" "+toString("",l_nVelCmd[3])+" "+toString("",l_nVelCmd[4])+" "+toString("",l_nVelCmd[5])+" ",false)
+        endIf
+      endIf
+    else
+      // stop immediately -- resetMotion() also ends velocity mode
+      resetMotion()
+      l_bVelReady=false
+
+      // set velocity motion command to initial state
+      motionCmdVel.nSequence=0
+
+      for l_nIndex=0 to 5
+        motionCmdVel.nVelCmd[l_nIndex]=0
+      endFor
+
+      // debug
+      if (bDebugMode and nDebugLevel==6)
+        call printDebug("motionCtrlVel: resetMotion()",true)
+        call printDebug("bStopNow: "+toString("",sel(bStopNow,1,0))+" inConn: "+toString("",nConnFlagMotion)+" outConn: "+toString("",nConnFlagState),false)
+      endIf
+
+      // reset stop flag
+      bStopNow=false
+    endIf
+
+    // sequence task
+    delay(0)
+  endWhile
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_server/printDebug.pgx
+++ b/staubli_val3_driver/val3/ros_server/printDebug.pgx
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="printDebug" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_sDebugMessage" type="string" use="value" xsi:type="element" dimensions="1" />
+      <Parameter name="x_bStamp" type="bool" use="value" xsi:type="element" dimensions="1" />
+    </Parameters>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // check whether cursor is at last line (keys line)
+  if (nDebugCursor==13)
+    // erase line before printing the message
+    put(scDebug,"                                        ")
+    gotoxy(scDebug,0,13)
+  endIf
+
+  // print message
+  if (x_bStamp)
+    // print timestamp
+    //put(scDebug,getDate("%H:%M:%S"))
+    put(scDebug, "[" + toString(".3", clock()) + "] ")
+  // else
+    // put(scDebug,"  ")
+  endIf
+  putln(scDebug,x_sDebugMessage)
+  nDebugCursor=sel(nDebugCursor==13,13,nDebugCursor+1)
+
+  // update keys line if necessary
+  if (nDebugCursor==13)
+    gotoxy(scDebug,0,13)
+    put(scDebug,"BACK")
+    gotoxy(scDebug,16,13)
+    put(scDebug,"CLS")
+    gotoxy(scDebug,31,13)
+    put(scDebug,"-")
+    gotoxy(scDebug,36,13)
+    put(scDebug,"+")
+    gotoxy(scDebug,0,13)
+  endIf
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_server/pushMotion.pgx
+++ b/staubli_val3_driver/val3/ros_server/pushMotion.pgx
@@ -2,16 +2,21 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="pushMotion" access="public">
     <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
-      <Parameter name="x_nMsgRecvState" type="num" xsi:type="element" use="reference" />
+      <Parameter name="x_msg" type="RosSimpleMsg" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nMsgRecvState" type="num" use="reference" xsi:type="element" dimensions="1" />
     </Parameters>
     <Locals>
       <Local name="l_bOk" type="bool" xsi:type="array" size="1" />
-      <Local name="l_nCounter" type="num" xsi:type="array" size="1" />
-      <Local name="l_nJointError" type="num" xsi:type="array" size="1" />
+      <Local name="l_motCfgVel" type="MotionCfgVel" xsi:type="array" size="1" />
+      <Local name="l_motCmdVel" type="MotionCmdVel" xsi:type="array" size="1" />
       <Local name="l_mTrajPt" type="MotionCmd" xsi:type="array" size="1" />
+      <Local name="l_nConversion" type="num" xsi:type="array" size="1" />
+      <Local name="l_nIndex" type="num" xsi:type="array" size="1" />
+      <Local name="l_nRad2Deg" type="num" xsi:type="array" size="1" />
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -26,91 +31,250 @@
   // limitations under the License.
 
 
+  l_nRad2Deg = 57.29577951308232
 
-  switch rosGenericMsg.header.nMsgType
-    case 11
-      l_mTrajPt.nSequence=rosTrajPtMsg.jointTrajPt.nSeq
+  // assume success to push motion
+  l_bOk = true
 
-      // ROS joint position values are in rad, but VAL3 uses degrees
-      call toJointRxDeg(rosTrajPtMsg.jointTrajPt.nJoints, l_mTrajPt.jJointRx)
+  if (rosStatusMsg.robotStatus.nMotionPossible == 0)
+    // don't push motion into buffer when motion not possible
+    l_bOk = false
+    // set stop flag so that the motion task resets motion and clears the motion buffers
+    bStopNow = true
+  endIf
 
-      // from industrial_robot_client/src/joint_trajectory_interface.cpp
-      // JointTrajectoryInterface::trajectory_to_msgs()
-      // JointTrajectoryInterface::calc_speed()
-      // velocity is converted to a scalar value representing % of max velocity,
-      // such that 0.2 = 20% of maximum joint speed
+  //region @get_data -- get data from message and store in local variable first
+  if (l_bOk)
+    switch x_msg.header.nMsgType
+      case SimpleMsg:MsgType.JOINT_TRAJ_PT
+        l_mTrajPt.nSequence = rosTrajPtMsg.jointTrajPt.nSeq
+
+        // ROS joint position values are in rad, but VAL3 uses degrees
+        call toJointRxDeg(rosTrajPtMsg.jointTrajPt.nJoints, l_mTrajPt.jJointRx)
+
+        // from industrial_robot_client/src/joint_trajectory_interface.cpp
+        // JointTrajectoryInterface::trajectory_to_msgs()
+        // JointTrajectoryInterface::calc_speed()
+        // velocity is converted to a scalar value representing % of max velocity,
+        // such that 0.2 = 20% of maximum joint speed
       l_mTrajPt.mDesc.vel= limit((rosTrajPtMsg.jointTrajPt.nVelocity * 100), 0, 100)
-      l_mTrajPt.nDuration=rosTrajPtMsg.jointTrajPt.nDuration
+        l_mTrajPt.nDuration=rosTrajPtMsg.jointTrajPt.nDuration
 
-    break
-    case 14
-      l_mTrajPt.nSequence=rosTrajPtFMsg.jointTrajPtFull.nSeq
-      l_mTrajPt.nDuration=rosTrajPtFMsg.jointTrajPtFull.nTime
+      break
+      case SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+        l_mTrajPt.nSequence=rosTrajPtFMsg.jointTrajPtFull.nSeq
+        l_mTrajPt.nDuration=rosTrajPtFMsg.jointTrajPtFull.nTime
 
-      // ROS joint position values are in rad, but VAL3 uses degrees
+        // ROS joint position values are in rad, but VAL3 uses degrees
       call toJointRxDeg(rosTrajPtFMsg.jointTrajPtFull.nPositions, l_mTrajPt.jJointRx)
 
-      // from industrial_robot_client/src/joint_trajectory_interface.cpp
-      // JointTrajectoryInterface::trajectory_to_msgs()
-      // JointTrajectoryInterface::calc_speed()
-      // velocity is converted to a scalar value representing % of max velocity,
-      // such that 0.2 = 20% of maximum joint speed
+        // from industrial_robot_client/src/joint_trajectory_interface.cpp
+        // JointTrajectoryInterface::trajectory_to_msgs()
+        // JointTrajectoryInterface::calc_speed()
+        // velocity is converted to a scalar value representing % of max velocity,
+        // such that 0.2 = 20% of maximum joint speed
       l_mTrajPt.mDesc.vel= limit((rosTrajPtFMsg.jointTrajPtFull.nVelocities[0] * 100), 0, 100)
-      // not sure about accelerations as yet
-      l_mTrajPt.mDesc.accel=rosTrajPtFMsg.jointTrajPtFull.nAccelerations[0]
-      l_mTrajPt.mDesc.decel=l_mTrajPt.mDesc.accel
-    break
-    default
-    break
-  endSwitch
+        // not sure about accelerations as yet
+        l_mTrajPt.mDesc.accel=rosTrajPtFMsg.jointTrajPtFull.nAccelerations[0]
+        l_mTrajPt.mDesc.decel=l_mTrajPt.mDesc.accel
+      break
+      // Staubli specific
+      case Staubli:MsgType.VELOCITY_CFG
+        l_motCfgVel.nCmdType=Staubli:velCfgMsg.velCfg.nCmdType
+        link(l_motCfgVel.fReference,world)
+        l_motCfgVel.fReference.trsf.x=Staubli:velCfgMsg.velCfg.nRefFrameVec[0]*1000
+        l_motCfgVel.fReference.trsf.y=Staubli:velCfgMsg.velCfg.nRefFrameVec[1]*1000
+        l_motCfgVel.fReference.trsf.z=Staubli:velCfgMsg.velCfg.nRefFrameVec[2]*1000
+        l_motCfgVel.fReference.trsf.rx=Staubli:velCfgMsg.velCfg.nRefFrameVec[3]*l_nRad2Deg
+        l_motCfgVel.fReference.trsf.ry=Staubli:velCfgMsg.velCfg.nRefFrameVec[4]*l_nRad2Deg
+        l_motCfgVel.fReference.trsf.rz=Staubli:velCfgMsg.velCfg.nRefFrameVec[5]*l_nRad2Deg
+        link(l_motCfgVel.tTool,flange)
+        l_motCfgVel.tTool.trsf.x=Staubli:velCfgMsg.velCfg.nToolVec[0]*1000
+        l_motCfgVel.tTool.trsf.y=Staubli:velCfgMsg.velCfg.nToolVec[1]*1000
+        l_motCfgVel.tTool.trsf.z=Staubli:velCfgMsg.velCfg.nToolVec[2]*1000
+        l_motCfgVel.tTool.trsf.rx=Staubli:velCfgMsg.velCfg.nToolVec[3]*l_nRad2Deg
+        l_motCfgVel.tTool.trsf.ry=Staubli:velCfgMsg.velCfg.nToolVec[4]*l_nRad2Deg
+        l_motCfgVel.tTool.trsf.rz=Staubli:velCfgMsg.velCfg.nToolVec[5]*l_nRad2Deg
+        l_motCfgVel.mMaxSpeed.accel=limit(Staubli:velCfgMsg.velCfg.nAccel*100,0,100)
+        l_motCfgVel.mMaxSpeed.vel=limit(Staubli:velCfgMsg.velCfg.nVel*100,0,100)
+        l_motCfgVel.mMaxSpeed.decel=l_motCfgVel.mMaxSpeed.accel
+        l_motCfgVel.mMaxSpeed.tvel=Staubli:velCfgMsg.velCfg.nTransVel*1000
+        l_motCfgVel.mMaxSpeed.rvel=Staubli:velCfgMsg.velCfg.nRotVel*l_nRad2Deg
+      break
+      case Staubli:MsgType.VELOCITY_CMD
+        l_motCmdVel.nSequence=Staubli:velCmdMsg.velCmd.nSeq
+        l_motCmdVel.nCmdType=Staubli:velCmdMsg.velCmd.nCmdType
+        if l_motCmdVel.nCmdType==Staubli:VelocityType.JOINT
+          for l_nIndex=0 to 5
+            l_motCmdVel.nVelCmd[l_nIndex]=Staubli:velCmdMsg.velCmd.nVelVec[l_nIndex]*l_nRad2Deg
+          endFor
+        elseIf (l_motCmdVel.nCmdType==Staubli:VelocityType.BASE_FRAME) or (l_motCmdVel.nCmdType==Staubli:VelocityType.TOOL_FRAME)
+          l_motCmdVel.nVelCmd[0]=Staubli:velCmdMsg.velCmd.nVelVec[0]*1000
+          l_motCmdVel.nVelCmd[1]=Staubli:velCmdMsg.velCmd.nVelVec[1]*1000
+          l_motCmdVel.nVelCmd[2]=Staubli:velCmdMsg.velCmd.nVelVec[2]*1000
+          l_motCmdVel.nVelCmd[3]=Staubli:velCmdMsg.velCmd.nVelVec[3]*l_nRad2Deg
+          l_motCmdVel.nVelCmd[4]=Staubli:velCmdMsg.velCmd.nVelVec[4]*l_nRad2Deg
+          l_motCmdVel.nVelCmd[5]=Staubli:velCmdMsg.velCmd.nVelVec[5]*l_nRad2Deg
+        else
+          popUpMsg("Failed to push velocity command. Invalid command type ("+toString("",motionCmdVel.nCmdType)+")")
+          for l_nIndex=0 to 5
+            l_motCmdVel.nVelCmd[l_nIndex]=0
+          endFor
+        endIf        
+      break
+      // unknown message type
+      default
+        l_bOk = false
+        //region @DEBUG
+        if (bDebugMode and nDebugLevel<=4)
+          call printDebug("ERROR: Unknown msg type ("+toString("",x_msg.header.nMsgType)+")",false)
+          call printDebug("       Failed to get data from msg",false)
+        endIf
+        //endregion
+      break
+    endSwitch
+    //endregion
 
-  // see github.com/ros-industrial/industrial_core/simple_message/include/simple_message/joint_traj_pt.h
-  if (l_mTrajPt.nSequence==-4)
-    // set flag to stop immediately
-    bStopNow=true
-  else
-    // check whether velocity value should be overwritten with value set on teach pendant
-    if (bOverwriteVel == true)
-      // overwrite velocity (and acceleration - ?)
-      l_mTrajPt.mDesc.vel = getMonitorSpeed()
-      // explicitly setting accel and decel to VAL3 default values
-      l_mTrajPt.mDesc.accel = 9999
-      l_mTrajPt.mDesc.decel = 9999
-    endIf
-    // only push motion into buffer if not a STOP message
-    // and if joint positions are within software joint limits
-    // and if velocity is greater than zero (beucase movej() will not accept vel <= 0)
-    if (isInRange(l_mTrajPt.jJointRx) and l_mTrajPt.mDesc.vel > 0)
-      call libQueueFuncs:push(qTrajPtBuffer,l_mTrajPt,l_bOk)
-    else
-      l_bOk = false
-    endIf
-    
-    if (l_bOk==false)
-      // could not push trajectory point into buffer
-      // thus ACK should flag FAILURE, but only if comm type is request
-      if (rosGenericMsg.header.nCommType==2)
-        switch rosGenericMsg.header.nMsgType
-          case 11
-            rosTrajPtAck.header.nReplyCode=2
-          break
-          case 14
-            rosTrajPtFAck.header.nReplyCode=2
-          break
-          default
-          break
-        endSwitch
+    //region @check_special_and_store -- check for special cases before storing motion command
+    switch x_msg.header.nMsgType
+      case SimpleMsg:MsgType.JOINT_TRAJ_PT,SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+        // see github.com/ros-industrial/industrial_core/simple_message/include/simple_message/joint_traj_pt.h
+        if (l_mTrajPt.nSequence==-4)
+          // set flag to stop immediately
+          bStopNow=true
+        else
+          // check whether velocity value should be overwritten with value set on teach pendant
+          if (bOverwriteVel == true)
+            // overwrite velocity (and acceleration - ?)
+            l_mTrajPt.mDesc.vel = getMonitorSpeed()
+            // explicitly setting accel and decel to VAL3 default values
+            l_mTrajPt.mDesc.accel = 9999
+            l_mTrajPt.mDesc.decel = 9999
+          endIf
+          // only push motion into buffer if not a STOP message
+          // and if joint positions are within software joint limits
+          // and if velocity is greater than zero (because movej() will not accept vel <= 0)
+          if (isInRange(l_mTrajPt.jJointRx) and l_mTrajPt.mDesc.vel > 0)
+            call libQueueFuncs:push(qTrajPtBuffer,l_mTrajPt,l_bOk)
+          else
+            l_bOk = false
+          endIf
+          //region @DEBUG
+          if (bDebugMode and nDebugLevel<=4)
+            call printDebug("pushMotion: Pushed traj pt",true)
+            call printDebug("bOk: "+toString("",sel(l_bOk,1,0))+" isInRange: "+toString("",sel(isInRange(l_mTrajPt.jJointRx),1,0))+" vel: "+toString("",l_mTrajPt.mDesc.vel),false)
+          endIf
+          //endregion
+        endIf
+      break
+      // Staubli specific
+      case Staubli:MsgType.VELOCITY_CFG
+        // @TODO -- check validity of data (e.g. l_motCfgVel.tvel > 0) before storing
+        // ... but now only store values in global variable for velocity motion configuration
+        motionCfgVel = l_motCfgVel
+        //region @DEBUG
+        if (bDebugMode and nDebugLevel<=4)
+          call printDebug("pushMotion: Pushed vel cfg", true)
+        endIf
+        //endregion
+      break
+      case Staubli:MsgType.VELOCITY_CMD
+        // check for special sequence number
+        if (l_motCmdVel.nSequence==SimpleMsg:SpecialSeqVal.STOP_TRAJECTORY)
+          bStopNow=true
+          //region @DEBUG
+          if (bDebugMode and nDebugLevel<=4)
+            call printDebug("pushMotion: Stop command!", true)
+          endIf
+          //endregion
+        else
+          // @TODO -- probably better to check if (l_motCmdVel.nCmdType == motionCfgVel.nCmdType) to
+          //          avoid that the values from l_motCmdVel.nVelCmd are processed with a wrong
+          //          reference (joint/frame)
+          motionCmdVel = l_motCmdVel
+          //region @DEBUG
+          if (bDebugMode and nDebugLevel<=4)
+            call printDebug("pushMotion: Pushed vel cmd", true)
+          endIf
+          //endregion
+        endIf
+      break
+      // unknown message type
+      default
+        l_bOk=false
+        //region @DEBUG
+        if (bDebugMode and nDebugLevel<=4)
+          call printDebug("ERROR: Unknown msg type ("+toString("",x_msg.header.nMsgType)+")",false)
+          call printDebug("       Failed to store motion data",false)
+        endIf
+        //endregion
+      break
+    endSwitch
+  endIf
+  //endregion
+
+  //region @check_success -- check whether storing was successful
+  if (l_bOk)
+    // if successful, setting motion message type and event flag for state machine
+    nMotionMsgType = x_msg.header.nMsgType
+    switch nMotionMsgType
+      case SimpleMsg:MsgType.JOINT_TRAJ_PT, SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+        bMotionMsgEvent=true
+      break
+      case Staubli:MsgType.VELOCITY_CFG
+        bMotionMsgEvent = true
+      break
+      default
+        // no state transition required
+      break
+    endSwitch
+
+    //region @DEBUG
+    if (bDebugMode and nDebugLevel<=4)
+      if (bMotionMsgEvent)
+        call printDebug("INFO: State transition event ("+toString("",nMotionMsgType)+")",false)
       endIf
     endIf
+    //endregion
+  else
+    // could not push trajectory point into buffer / store motion command
+    // thus ACK should flag FAILURE, but only if comm type is request
+    if (x_msg.header.nCommType==SimpleMsg:CommType.SERVICE_REQUEST)
+      switch x_msg.header.nMsgType
+        case SimpleMsg:MsgType.JOINT_TRAJ_PT
+          rosTrajPtAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        case SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+          rosTrajPtFAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        // Staubli specific
+        case Staubli:MsgType.VELOCITY_CFG
+          Staubli:velCfgAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        case Staubli:MsgType.VELOCITY_CMD
+          Staubli:velCmdAck.header.nReplyCode=SimpleMsg:ReplyCode.FAILURE
+        break
+        default
+        break
+      endSwitch
+    endIf
+    //region @DEBUG
+    if (bDebugMode and nDebugLevel<=4)
+      call printDebug("ERROR: Push motion failed",false)
+    endIf
+    //endregion
   endIf
-  // check whether ACK should be sent
-  if (rosGenericMsg.header.nCommType == 2)
+  //endregion
+
+  //region @check_reply -- check whether service reply (ACK) should be sent
+  if (x_msg.header.nCommType == SimpleMsg:CommType.SERVICE_REQUEST)
     // comm type request requires ACK
-    x_nMsgRecvState = 5
+    x_nMsgRecvState = MsgRecvState.SEND_ACK
   else
     // other comm types (e.g., topic) does not require ACK, hence skip state
-    x_nMsgRecvState = 0
+    x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
   endIf
+  //endregion
 end]]></Code>
   </Program>
 </Programs>

--- a/staubli_val3_driver/val3/ros_server/recvData.pgx
+++ b/staubli_val3_driver/val3/ros_server/recvData.pgx
@@ -14,6 +14,7 @@
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -44,6 +45,8 @@
       l_nBytesRecv=l_nBytesRecv+1
       // received a byte, set flag to indicate connection
       x_nConnFlag=1
+      // set global flag to indicate incoming data
+      bDataIn=true
     elseIf (l_nIndex==-1)
       // error or timeout, indicate only if connection previously established
       if (x_nConnFlag==1)

--- a/staubli_val3_driver/val3/ros_server/recvHeartbeat.pgx
+++ b/staubli_val3_driver/val3/ros_server/recvHeartbeat.pgx
@@ -10,6 +10,7 @@
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -27,20 +28,20 @@
 
   while (true)
     l_nBytesRecv=0
-    l_nIndex = sioGet(siTcpIpFbk, l_nByte)
+    l_nIndex = sioGet(siTcpIpState, l_nByte)
     if (l_nIndex == -1)
       // connection not established or connection lost
-      if (nOutConnFlag == 1)
-        nOutConnFlag = -1
+      if (nConnFlagState == 1)
+        nConnFlagState = -1
       endIf
     else
       // it means l_nIndex >= 0: connection established
       // check if connection had not already been established
-      if (nOutConnFlag != 1)
+      if (nConnFlagState != 1)
         // delay data output to avoid sync issues with client
         delay(1.0)
         // flag connection as established
-        nOutConnFlag = 1
+        nConnFlagState = 1
       endIf
     endIf
   endWhile

--- a/staubli_val3_driver/val3/ros_server/recvMsgBody.pgx
+++ b/staubli_val3_driver/val3/ros_server/recvMsgBody.pgx
@@ -2,6 +2,9 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="recvMsgBody" access="public">
     <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
+      <Parameter name="x_sSocket" type="sio" xsi:type="element" use="reference" />
+      <Parameter name="x_nConnFlag" type="num" xsi:type="element" use="reference" />
+      <Parameter name="x_msg" type="RosSimpleMsg" xsi:type="element" use="reference" />
       <Parameter name="x_nMsgRecvState" type="num" xsi:type="element" use="reference" />
     </Parameters>
     <Locals>
@@ -9,6 +12,7 @@
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -26,23 +30,51 @@
 
   l_bFlag=false
 
-  switch rosGenericMsg.header.nMsgType
-    case 11
-      call recvTrajPt(l_bFlag)
+  switch x_msg.header.nMsgType
+    // standard ROS industrial messages
+    case SimpleMsg:MsgType.JOINT_TRAJ_PT
+      call recvTrajPt(x_sSocket, x_nConnFlag, x_msg, l_bFlag)
     break
-    case 14
-      call recvTrajPtFull(l_bFlag)
+    case SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+      call recvTrajPtFull(x_sSocket,x_nConnFlag,x_msg,l_bFlag)
+    break
+    // Staubli specific
+    case Staubli:MsgType.SET_DRIVE_POWER
+      call recvRosMsg(x_sSocket, Staubli:setDrvPwrMsg.prefix, Staubli:setDrvPwrMsg.header, Staubli:setDrvPwrMsg.body, x_nConnFlag, x_msg, l_bFlag)
+    break
+    case Staubli:MsgType.WRITE_SINGLE_IO
+      call recvRosMsg(x_sSocket, Staubli:writeSingIOMsg.prefix, Staubli:writeSingIOMsg.header, Staubli:writeSingIOMsg.body, x_nConnFlag, x_msg, l_bFlag)
+    break
+    case Staubli:MsgType.VELOCITY_CFG
+      call recvRosMsg(x_sSocket, Staubli:velCfgMsg.prefix, Staubli:velCfgMsg.header, Staubli:velCfgMsg.body, x_nConnFlag, x_msg, l_bFlag)
+    break
+    case Staubli:MsgType.VELOCITY_CMD
+      call recvRosMsg(x_sSocket, Staubli:velCmdMsg.prefix, Staubli:velCmdMsg.header, Staubli:velCmdMsg.body, x_nConnFlag, x_msg, l_bFlag)
     break
     default
+      if (bDebugMode and nDebugLevel<=2)
+        call printDebug("ERROR: unknown msg type ("+toString("",x_msg.header.nMsgType)+")",false)
+      endIf
     break
   endSwitch
 
   if (l_bFlag == true)
     // move on to state 3: decode msg body
-    x_nMsgRecvState=3
+    x_nMsgRecvState = MsgRecvState.DECODE_BODY
+
+    // debug
+    if (bDebugMode and nDebugLevel<=2)
+      call printDebug("INFO: receiving successful",false)
+    endIf
   else
     // error whilst receiving msg body, reset state machine
-    x_nMsgRecvState=0
+    x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
+    clearBuffer(x_sSocket)
+
+    // debug
+    if (bDebugMode and nDebugLevel<=2)
+      call printDebug("ERROR: receiving not successful",false)
+    endIf
   endIf
 end]]></Code>
   </Program>

--- a/staubli_val3_driver/val3/ros_server/recvMsgHeader.pgx
+++ b/staubli_val3_driver/val3/ros_server/recvMsgHeader.pgx
@@ -2,13 +2,17 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="recvMsgHeader" access="public">
     <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
-      <Parameter name="x_nMsgRecvState" type="num" xsi:type="element" use="reference" />
+      <Parameter name="x_sSocket" type="sio" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nConnFlag" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_msg" type="RosSimpleMsg" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nMsgRecvState" type="num" use="reference" xsi:type="element" dimensions="1" />
     </Parameters>
     <Locals>
       <Local name="l_bFlag" type="bool" xsi:type="array" size="1" />
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -25,17 +29,17 @@
 
 
   // attempt to receive message prefix and header
-  call recvData(siTcpIpMotion,rosGenericMsg.prefix.nData,nInConnFlag,l_bFlag)
-  if (l_bFlag == true)
-    call recvData(siTcpIpMotion,rosGenericMsg.header.nData,nInConnFlag,l_bFlag)
+  call recvData(x_sSocket,x_msg.prefix.nData,x_nConnFlag,l_bFlag)
+  if (l_bFlag==true)
+    call recvData(x_sSocket,x_msg.header.nData,x_nConnFlag,l_bFlag)
   endIf
 
   if (l_bFlag == true)
     // move on to state 1: decode header
-    x_nMsgRecvState=1
+    x_nMsgRecvState = MsgRecvState.DECODE_HEADER
   else
     // error: reset state to 0: receive header
-    x_nMsgRecvState=0
+    x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
   endIf
 end]]></Code>
   </Program>

--- a/staubli_val3_driver/val3/ros_server/recvRosMsg.pgx
+++ b/staubli_val3_driver/val3/ros_server/recvRosMsg.pgx
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="recvRosMsg" access="private" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_sSocket" type="sio" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_pPrefix" type="Prefix" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_hHeader" type="Header" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_bBody" type="Body" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nConnFlag" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_msg" type="RosSimpleMsg" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_bValidFlag" type="bool" use="reference" xsi:type="element" dimensions="1" />
+    </Parameters>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  // attempt to receive the data of the message (prefix and header are in x_msg)
+  x_pPrefix.nLength=x_msg.prefix.nLength
+  x_hHeader.nMsgType=x_msg.header.nMsgType
+  x_hHeader.nCommType=x_msg.header.nCommType
+  x_hHeader.nReplyCode=x_msg.header.nReplyCode
+
+  call recvData(x_sSocket,x_bBody.nData,x_nConnFlag,x_bValidFlag)
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_server/recvTrajPt.pgx
+++ b/staubli_val3_driver/val3/ros_server/recvTrajPt.pgx
@@ -2,10 +2,14 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="recvTrajPt" access="public">
     <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
-      <Parameter name="x_bFlag" type="bool" xsi:type="element" use="reference" />
+      <Parameter name="x_sSocket" type="sio" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nConnFlag" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_msg" type="RosSimpleMsg" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_bFlag" type="bool" use="reference" xsi:type="element" dimensions="1" />
     </Parameters>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -21,13 +25,13 @@
 
 
 
-  // attempt to receive message ID 11 data (prefix and header are in rosGenericMsg)
-  rosTrajPtMsg.prefix.nLength=rosGenericMsg.prefix.nLength
-  rosTrajPtMsg.header.nMsgType=rosGenericMsg.header.nMsgType
-  rosTrajPtMsg.header.nCommType=rosGenericMsg.header.nCommType
-  rosTrajPtMsg.header.nReplyCode=rosGenericMsg.header.nReplyCode
+  // attempt to receive message ID 11 data (prefix and header are in x_msg)
+  rosTrajPtMsg.prefix.nLength=x_msg.prefix.nLength
+  rosTrajPtMsg.header.nMsgType=x_msg.header.nMsgType
+  rosTrajPtMsg.header.nCommType=x_msg.header.nCommType
+  rosTrajPtMsg.header.nReplyCode=x_msg.header.nReplyCode
 
-  call recvData(siTcpIpMotion,rosTrajPtMsg.body.nData,nInConnFlag,x_bFlag)
+  call recvData(x_sSocket,rosTrajPtMsg.body.nData,x_nConnFlag,x_bFlag)
 end]]></Code>
   </Program>
 </Programs>

--- a/staubli_val3_driver/val3/ros_server/recvTrajPtFull.pgx
+++ b/staubli_val3_driver/val3/ros_server/recvTrajPtFull.pgx
@@ -2,10 +2,14 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="recvTrajPtFull" access="public">
     <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
-      <Parameter name="x_bFlag" type="bool" xsi:type="element" use="reference" />
+      <Parameter name="x_sSocket" type="sio" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_nConnFlag" type="num" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_msg" type="RosSimpleMsg" use="reference" xsi:type="element" dimensions="1" />
+      <Parameter name="x_bFlag" type="bool" use="reference" xsi:type="element" dimensions="1" />
     </Parameters>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -21,13 +25,13 @@
 
 
 
-  // receive message ID 14 data (prefix and header are in rosGenericMsg)
-  rosTrajPtFMsg.prefix.nLength=rosGenericMsg.prefix.nLength
-  rosTrajPtFMsg.header.nMsgType=rosGenericMsg.header.nMsgType
-  rosTrajPtFMsg.header.nCommType=rosGenericMsg.header.nCommType
-  rosTrajPtFMsg.header.nReplyCode=rosGenericMsg.header.nReplyCode
+  // receive message ID 14 data (prefix and header are in x_msg)
+  rosTrajPtFMsg.prefix.nLength=x_msg.prefix.nLength
+  rosTrajPtFMsg.header.nMsgType=x_msg.header.nMsgType
+  rosTrajPtFMsg.header.nCommType=x_msg.header.nCommType
+  rosTrajPtFMsg.header.nReplyCode=x_msg.header.nReplyCode
 
-  call recvData(siTcpIpMotion,rosTrajPtFMsg.body.nData,nInConnFlag,x_bFlag)
+  call recvData(x_sSocket,rosTrajPtFMsg.body.nData,x_nConnFlag,x_bFlag)
 end]]></Code>
   </Program>
 </Programs>

--- a/staubli_val3_driver/val3/ros_server/ros_server.dtx
+++ b/staubli_val3_driver/val3/ros_server/ros_server.dtx
@@ -1,41 +1,436 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Database xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Data/2">
   <Datas>
-    <Data name="bFbkOverrun" access="public" xsi:type="array" type="bool" size="1" />
-    <Data name="bMotionOverrun" access="public" xsi:type="array" type="bool" size="1" />
-    <Data name="siTcpIpFbk" access="public" xsi:type="array" type="sio" size="1">
-      <Value key="0" link="Socket\Feedback" />
-    </Data>
-    <Data name="siTcpIpMotion" access="public" xsi:type="array" type="sio" size="1">
-      <Value key="0" link="Socket\Motion" />
-    </Data>
-    <Data name="sStreamTaskName" access="public" xsi:type="array" type="string" size="1">
-      <Value key="0" value="publisher" />
-    </Data>
-    <Data name="sMotionTaskName" access="public" xsi:type="array" type="string" size="1" />
-    <Data name="rosGenericMsg" access="public" xsi:type="array" type="RosSimpleMsg" size="1">
+    <Data name="rosJointFbkMsg" access="public" xsi:type="array" type="JointFbkMsg" size="1">
       <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="132" />
+          </Value>
+        </Field>
         <Field name="header" xsi:type="array" type="Header" size="1">
           <Value key="0">
-            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
-            <Field name="nCommType" xsi:type="array" type="num" size="1" />
-            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+            <Field name="nCommType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="1" />
+            </Field>
             <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="15" />
+            </Field>
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="jointFeedback" xsi:type="array" type="JointFeedback" size="1">
+          <Value key="0">
+            <Field name="nAccelerations" xsi:type="array" type="num" size="10" />
+            <Field name="nPositions" xsi:type="array" type="num" size="10" />
+            <Field name="nRobotId" xsi:type="array" type="num" size="1" />
+            <Field name="nTime" xsi:type="array" type="num" size="1" />
+            <Field name="nValidFields" xsi:type="array" type="num" size="1" />
+            <Field name="nVelocities" xsi:type="array" type="num" size="10" />
           </Value>
         </Field>
         <Field name="prefix" xsi:type="array" type="Prefix" size="1">
           <Value key="0">
-            <Field name="nLength" xsi:type="array" type="num" size="1" />
             <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="144" />
+            </Field>
           </Value>
         </Field>
       </Value>
     </Data>
-    <Data name="tTool" access="public" xsi:type="array" type="tool" size="1">
-      <Value key="0" fatherId="flange[0]" ioLink="valve1" />
+    <Data name="rosJointMsg" access="public" xsi:type="array" type="JointStateMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="44" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="1" />
+            </Field>
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="10" />
+            </Field>
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="jointState" xsi:type="array" type="JointState" size="1">
+          <Value key="0">
+            <Field name="nJoints" xsi:type="array" type="num" size="10" />
+            <Field name="nSeq" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="56" />
+            </Field>
+          </Value>
+        </Field>
+      </Value>
     </Data>
-    <Data name="sTrajPtTaskName" access="public" xsi:type="array" type="string" size="1" />
-    <Data name="bTrajPtOverrun" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="rosTrajPtFAck" access="public" xsi:type="array" type="JointTrajPtFMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="136" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="3" />
+            </Field>
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="14" />
+            </Field>
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1">
+              <Value key="0" value="1" />
+            </Field>
+          </Value>
+        </Field>
+        <Field name="jointTrajPtFull" xsi:type="array" type="JointTrajPtFull" size="1">
+          <Value key="0">
+            <Field name="nAccelerations" xsi:type="array" type="num" size="10" />
+            <Field name="nPositions" xsi:type="array" type="num" size="10" />
+            <Field name="nRobotId" xsi:type="array" type="num" size="1" />
+            <Field name="nSeq" xsi:type="array" type="num" size="1" />
+            <Field name="nTime" xsi:type="array" type="num" size="1" />
+            <Field name="nValidFields" xsi:type="array" type="num" size="1" />
+            <Field name="nVelocities" xsi:type="array" type="num" size="10" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="148" />
+            </Field>
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="rosTrajPtFMsg" access="public" xsi:type="array" type="JointTrajPtFMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="136" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="jointTrajPtFull" xsi:type="array" type="JointTrajPtFull" size="1">
+          <Value key="0">
+            <Field name="nAccelerations" xsi:type="array" type="num" size="10" />
+            <Field name="nPositions" xsi:type="array" type="num" size="10" />
+            <Field name="nRobotId" xsi:type="array" type="num" size="1" />
+            <Field name="nSeq" xsi:type="array" type="num" size="1" />
+            <Field name="nTime" xsi:type="array" type="num" size="1" />
+            <Field name="nValidFields" xsi:type="array" type="num" size="1" />
+            <Field name="nVelocities" xsi:type="array" type="num" size="10" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="148" />
+            </Field>
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="rosTrajPtAck" access="public" xsi:type="array" type="JointTrajPtMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="52" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="3" />
+            </Field>
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="11" />
+            </Field>
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1">
+              <Value key="0" value="1" />
+            </Field>
+          </Value>
+        </Field>
+        <Field name="jointTrajPt" xsi:type="array" type="JointTrajPt" size="1">
+          <Value key="0">
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nJoints" xsi:type="array" type="num" size="10" />
+            <Field name="nSeq" xsi:type="array" type="num" size="1" />
+            <Field name="nVelocity" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="64" />
+            </Field>
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="rosTrajPtMsg" access="public" xsi:type="array" type="JointTrajPtMsg" size="1">
+      <Value key="0">
+        <Field name="body" xsi:type="array" type="Body" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="52" />
+          </Value>
+        </Field>
+        <Field name="header" xsi:type="array" type="Header" size="1">
+          <Value key="0">
+            <Field name="nCommType" xsi:type="array" type="num" size="1" />
+            <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="jointTrajPt" xsi:type="array" type="JointTrajPt" size="1">
+          <Value key="0">
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nJoints" xsi:type="array" type="num" size="10" />
+            <Field name="nSeq" xsi:type="array" type="num" size="1" />
+            <Field name="nVelocity" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
+          <Value key="0">
+            <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="64" />
+            </Field>
+          </Value>
+        </Field>
+      </Value>
+    </Data>
+    <Data name="motionCfgVel" access="private" xsi:type="array" type="MotionCfgVel" size="1">
+      <Value key="0">
+        <Field name="fReference" xsi:type="array" type="frame" size="1">
+          <Value key="0" fatherId="world[0]" />
+        </Field>
+        <Field name="mMaxSpeed" xsi:type="array" type="mdesc" size="1">
+          <Value key="0" leave="1" reach="1" blend="off" />
+        </Field>
+        <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+        <Field name="tTool" xsi:type="array" type="tool" size="1">
+          <Value key="0" fatherId="flange[0]" ioLink="valve1" />
+        </Field>
+      </Value>
+    </Data>
+    <Data name="motionCmdVel" access="private" xsi:type="array" type="MotionCmdVel" size="1">
+      <Value key="0">
+        <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+        <Field name="nSequence" xsi:type="array" type="num" size="1" />
+        <Field name="nVelCmd" xsi:type="array" type="num" size="6" />
+      </Value>
+    </Data>
+    <Data name="actMotionCmdVel" access="private" xsi:type="array" type="MotionCmdVel" size="1">
+      <Value key="0">
+        <Field name="nCmdType" xsi:type="array" type="num" size="1" />
+        <Field name="nSequence" xsi:type="array" type="num" size="1" />
+        <Field name="nVelCmd" xsi:type="array" type="num" size="6" />
+      </Value>
+    </Data>
+    <Data name="qMoveBuffer" access="public" xsi:type="array" type="Queue" size="1">
+      <Value key="0">
+        <Field name="buffer" xsi:type="array" type="MotionCmd" size="10">
+          <Value key="0">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="1">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="2">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="3">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="4">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="5">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="6">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="7">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="8">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="9">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="nElems" xsi:type="array" type="num" size="1" />
+        <Field name="nPop" xsi:type="array" type="num" size="1" />
+        <Field name="nPush" xsi:type="array" type="num" size="1" />
+      </Value>
+    </Data>
+    <Data name="qTrajPtBuffer" access="public" xsi:type="array" type="Queue" size="1">
+      <Value key="0">
+        <Field name="buffer" xsi:type="array" type="MotionCmd" size="10">
+          <Value key="0">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="1">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="2">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="3">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="4">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="5">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="6">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="7">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="8">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+          <Value key="9">
+            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
+            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
+              <Value key="0" leave="0" reach="0" />
+            </Field>
+            <Field name="nDuration" xsi:type="array" type="num" size="1" />
+            <Field name="nSequence" xsi:type="array" type="num" size="1" />
+          </Value>
+        </Field>
+        <Field name="nElems" xsi:type="array" type="num" size="1" />
+        <Field name="nPop" xsi:type="array" type="num" size="1" />
+        <Field name="nPush" xsi:type="array" type="num" size="1" />
+      </Value>
+    </Data>
     <Data name="rosStatusMsg" access="public" xsi:type="array" type="RobotStatusMsg" size="1">
       <Value key="0">
         <Field name="body" xsi:type="array" type="Body" size="1">
@@ -45,16 +440,22 @@
         </Field>
         <Field name="header" xsi:type="array" type="Header" size="1">
           <Value key="0">
-            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
-            <Field name="nCommType" xsi:type="array" type="num" size="1" />
-            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
+            <Field name="nCommType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="1" />
+            </Field>
             <Field name="nData" xsi:type="array" type="num" size="12" />
+            <Field name="nMsgType" xsi:type="array" type="num" size="1">
+              <Value key="0" value="13" />
+            </Field>
+            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
           </Value>
         </Field>
         <Field name="prefix" xsi:type="array" type="Prefix" size="1">
           <Value key="0">
-            <Field name="nLength" xsi:type="array" type="num" size="1" />
             <Field name="nData" xsi:type="array" type="num" size="4" />
+            <Field name="nLength" xsi:type="array" type="num" size="1">
+              <Value key="0" value="40" />
+            </Field>
           </Value>
         </Field>
         <Field name="robotStatus" xsi:type="array" type="RobotStatus" size="1">
@@ -70,67 +471,7 @@
         </Field>
       </Value>
     </Data>
-    <Data name="rosJointMsg" access="public" xsi:type="array" type="JointStateMsg" size="1">
-      <Value key="0">
-        <Field name="header" xsi:type="array" type="Header" size="1">
-          <Value key="0">
-            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
-            <Field name="nCommType" xsi:type="array" type="num" size="1" />
-            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
-            <Field name="nData" xsi:type="array" type="num" size="12" />
-          </Value>
-        </Field>
-        <Field name="body" xsi:type="array" type="Body" size="1">
-          <Value key="0">
-            <Field name="nData" xsi:type="array" type="num" size="44" />
-          </Value>
-        </Field>
-        <Field name="jointState" xsi:type="array" type="JointState" size="1">
-          <Value key="0">
-            <Field name="nSeq" xsi:type="array" type="num" size="1" />
-            <Field name="nJoints" xsi:type="array" type="num" size="10" />
-          </Value>
-        </Field>
-        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
-          <Value key="0">
-            <Field name="nLength" xsi:type="array" type="num" size="1" />
-            <Field name="nData" xsi:type="array" type="num" size="4" />
-          </Value>
-        </Field>
-      </Value>
-    </Data>
-    <Data name="rosTrajPtMsg" access="public" xsi:type="array" type="JointTrajPtMsg" size="1">
-      <Value key="0">
-        <Field name="header" xsi:type="array" type="Header" size="1">
-          <Value key="0">
-            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
-            <Field name="nCommType" xsi:type="array" type="num" size="1" />
-            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
-            <Field name="nData" xsi:type="array" type="num" size="12" />
-          </Value>
-        </Field>
-        <Field name="jointTrajPt" xsi:type="array" type="JointTrajPt" size="1">
-          <Value key="0">
-            <Field name="nSeq" xsi:type="array" type="num" size="1" />
-            <Field name="nJoints" xsi:type="array" type="num" size="10" />
-            <Field name="nVelocity" xsi:type="array" type="num" size="1" />
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-          </Value>
-        </Field>
-        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
-          <Value key="0">
-            <Field name="nLength" xsi:type="array" type="num" size="1" />
-            <Field name="nData" xsi:type="array" type="num" size="4" />
-          </Value>
-        </Field>
-        <Field name="body" xsi:type="array" type="Body" size="1">
-          <Value key="0">
-            <Field name="nData" xsi:type="array" type="num" size="52" />
-          </Value>
-        </Field>
-      </Value>
-    </Data>
-    <Data name="rosTrajPtFMsg" access="public" xsi:type="array" type="JointTrajPtFMsg" size="1">
+    <Data name="genericMotMsg" access="public" xsi:type="array" type="RosSimpleMsg" size="1">
       <Value key="0">
         <Field name="header" xsi:type="array" type="Header" size="1">
           <Value key="0">
@@ -146,25 +487,9 @@
             <Field name="nData" xsi:type="array" type="num" size="4" />
           </Value>
         </Field>
-        <Field name="jointTrajPtFull" xsi:type="array" type="JointTrajPtFull" size="1">
-          <Value key="0">
-            <Field name="nRobotId" xsi:type="array" type="num" size="1" />
-            <Field name="nSeq" xsi:type="array" type="num" size="1" />
-            <Field name="nValidFields" xsi:type="array" type="num" size="1" />
-            <Field name="nTime" xsi:type="array" type="num" size="1" />
-            <Field name="nPositions" xsi:type="array" type="num" size="10" />
-            <Field name="nVelocities" xsi:type="array" type="num" size="10" />
-            <Field name="nAccelerations" xsi:type="array" type="num" size="10" />
-          </Value>
-        </Field>
-        <Field name="body" xsi:type="array" type="Body" size="1">
-          <Value key="0">
-            <Field name="nData" xsi:type="array" type="num" size="136" />
-          </Value>
-        </Field>
       </Value>
     </Data>
-    <Data name="rosJointFbkMsg" access="public" xsi:type="array" type="JointFbkMsg" size="1">
+    <Data name="genericSysMsg" access="public" xsi:type="array" type="RosSimpleMsg" size="1">
       <Value key="0">
         <Field name="header" xsi:type="array" type="Header" size="1">
           <Value key="0">
@@ -180,24 +505,9 @@
             <Field name="nData" xsi:type="array" type="num" size="4" />
           </Value>
         </Field>
-        <Field name="jointFeedback" xsi:type="array" type="JointFeedback" size="1">
-          <Value key="0">
-            <Field name="nRobotId" xsi:type="array" type="num" size="1" />
-            <Field name="nValidFields" xsi:type="array" type="num" size="1" />
-            <Field name="nTime" xsi:type="array" type="num" size="1" />
-            <Field name="nPositions" xsi:type="array" type="num" size="10" />
-            <Field name="nVelocities" xsi:type="array" type="num" size="10" />
-            <Field name="nAccelerations" xsi:type="array" type="num" size="10" />
-          </Value>
-        </Field>
-        <Field name="body" xsi:type="array" type="Body" size="1">
-          <Value key="0">
-            <Field name="nData" xsi:type="array" type="num" size="132" />
-          </Value>
-        </Field>
       </Value>
     </Data>
-    <Data name="rosTrajPtFAck" access="public" xsi:type="array" type="JointTrajPtFMsg" size="1">
+    <Data name="genericIOMsg" access="public" xsi:type="array" type="RosSimpleMsg" size="1">
       <Value key="0">
         <Field name="header" xsi:type="array" type="Header" size="1">
           <Value key="0">
@@ -213,247 +523,98 @@
             <Field name="nData" xsi:type="array" type="num" size="4" />
           </Value>
         </Field>
-        <Field name="jointTrajPtFull" xsi:type="array" type="JointTrajPtFull" size="1">
-          <Value key="0">
-            <Field name="nRobotId" xsi:type="array" type="num" size="1" />
-            <Field name="nSeq" xsi:type="array" type="num" size="1" />
-            <Field name="nValidFields" xsi:type="array" type="num" size="1" />
-            <Field name="nTime" xsi:type="array" type="num" size="1" />
-            <Field name="nPositions" xsi:type="array" type="num" size="10" />
-            <Field name="nVelocities" xsi:type="array" type="num" size="10" />
-            <Field name="nAccelerations" xsi:type="array" type="num" size="10" />
-          </Value>
-        </Field>
-        <Field name="body" xsi:type="array" type="Body" size="1">
-          <Value key="0">
-            <Field name="nData" xsi:type="array" type="num" size="136" />
-          </Value>
-        </Field>
       </Value>
     </Data>
-    <Data name="rosTrajPtAck" access="public" xsi:type="array" type="JointTrajPtMsg" size="1">
+    <Data name="MsgRecvState" access="public" xsi:type="array" type="_MsgRecvState" size="1">
       <Value key="0">
-        <Field name="header" xsi:type="array" type="Header" size="1">
-          <Value key="0">
-            <Field name="nMsgType" xsi:type="array" type="num" size="1" />
-            <Field name="nCommType" xsi:type="array" type="num" size="1" />
-            <Field name="nReplyCode" xsi:type="array" type="num" size="1" />
-            <Field name="nData" xsi:type="array" type="num" size="12" />
-          </Value>
-        </Field>
-        <Field name="jointTrajPt" xsi:type="array" type="JointTrajPt" size="1">
-          <Value key="0">
-            <Field name="nSeq" xsi:type="array" type="num" size="1" />
-            <Field name="nJoints" xsi:type="array" type="num" size="10" />
-            <Field name="nVelocity" xsi:type="array" type="num" size="1" />
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-          </Value>
-        </Field>
-        <Field name="prefix" xsi:type="array" type="Prefix" size="1">
-          <Value key="0">
-            <Field name="nLength" xsi:type="array" type="num" size="1" />
-            <Field name="nData" xsi:type="array" type="num" size="4" />
-          </Value>
-        </Field>
-        <Field name="body" xsi:type="array" type="Body" size="1">
-          <Value key="0">
-            <Field name="nData" xsi:type="array" type="num" size="52" />
-          </Value>
-        </Field>
+        <Field name="DECODE_BODY" xsi:type="array" type="num" size="1" />
+        <Field name="DECODE_HEADER" xsi:type="array" type="num" size="1" />
+        <Field name="HANDLE_REQUEST" xsi:type="array" type="num" size="1" />
+        <Field name="PUSH_MOTION" xsi:type="array" type="num" size="1" />
+        <Field name="RECEIVE_BODY" xsi:type="array" type="num" size="1" />
+        <Field name="RECEIVE_HEADER" xsi:type="array" type="num" size="1" />
+        <Field name="SEND_ACK" xsi:type="array" type="num" size="1" />
       </Value>
     </Data>
+    <Data name="bDataIn" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="bDataOut" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="bDebugMode" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="bFbkOverrun" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="bMotionMsgEvent" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="bMotionOverrun" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="bOverwriteVel" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="bRecvOverrun" access="public" xsi:type="array" type="bool" size="1" />
     <Data name="bScreenOverrun" access="public" xsi:type="array" type="bool" size="1" />
-    <Data name="sScreenTaskName" access="public" xsi:type="array" type="string" size="1" />
-    <Data name="nInConnFlag" access="public" xsi:type="array" type="num" size="1" />
-    <Data name="nOutConnFlag" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="bShowDebug" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="bStopNow" access="public" xsi:type="array" type="bool" size="1" />
+    <Data name="nConnFlagIO" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nConnFlagMotion" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nConnFlagState" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nConnFlagSystem" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nDebugCursor" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nDebugLevel" access="public" xsi:type="array" type="num" size="1">
+      <Value key="0" value="5" />
+    </Data>
+    <Data name="nDebugLevelMax" access="public" xsi:type="array" type="num" size="1">
+      <Value key="0" value="7" />
+    </Data>
+    <Data name="nElapsedTime" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nHeaderTime" access="public" xsi:type="array" type="num" size="1">
+      <Value key="0" value="0.004" />
+    </Data>
+    <Data name="nMotionMode" access="private" xsi:type="array" type="num" size="1">
+      <Value key="0" value="1" />
+    </Data>
+    <Data name="nMotionMsgType" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nMotionPeriod" access="private" xsi:type="array" type="num" size="1">
+      <Value key="0" value="0.004" />
+    </Data>
+    <Data name="nMotionProgress" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nMoveId" access="public" xsi:type="array" type="num" size="1">
+      <Value key="0" value="-1" />
+    </Data>
+    <Data name="nMovePts" access="public" xsi:type="array" type="num" size="1" />
+    <Data name="nPtsPopped" access="public" xsi:type="array" type="num" size="1" />
     <Data name="scDebug" access="public" xsi:type="array" type="screen" size="1" />
     <Data name="scMonitor" access="public" xsi:type="array" type="screen" size="1" />
-    <Data name="sHtbtTaskName" access="public" xsi:type="array" type="string" size="1" />
-    <Data name="nPtsPopped" access="public" xsi:type="array" type="num" size="1" />
-    <Data name="bStopNow" access="public" xsi:type="array" type="bool" size="1" />
-    <Data name="nMotionProgress" access="public" xsi:type="array" type="num" size="1" />
-    <Data name="nMoveId" access="public" xsi:type="array" type="num" size="1" />
-    <Data name="nMovePts" access="public" xsi:type="array" type="num" size="1" />
-    <Data name="nElapsedTime" access="public" xsi:type="array" type="num" size="1" />
-    <Data name="nHeaderTime" access="public" xsi:type="array" type="num" size="1" />
-    <Data name="bOverwriteVel" access="public" xsi:type="array" type="bool" size="1" />
-    <Data name="qMoveBuffer" access="public" xsi:type="array" type="Queue" size="1">
-      <Value key="0">
-        <Field name="nPush" xsi:type="array" type="num" size="1" />
-        <Field name="nPop" xsi:type="array" type="num" size="1" />
-        <Field name="nElems" xsi:type="array" type="num" size="1" />
-        <Field name="buffer" xsi:type="array" type="MotionCmd" size="10">
-          <Value key="0">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="1">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="2">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="3">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="4">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="5">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="6">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="7">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="8">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="9">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-        </Field>
-      </Value>
+    <Data name="siTcpIpIO" access="public" xsi:type="array" type="sio" size="1">
+      <Value key="0" link="Socket\IO" />
     </Data>
-    <Data name="qTrajPtBuffer" access="public" xsi:type="array" type="Queue" size="1">
-      <Value key="0">
-        <Field name="nPush" xsi:type="array" type="num" size="1" />
-        <Field name="nPop" xsi:type="array" type="num" size="1" />
-        <Field name="nElems" xsi:type="array" type="num" size="1" />
-        <Field name="buffer" xsi:type="array" type="MotionCmd" size="10">
-          <Value key="0">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="1">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="2">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="3">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="4">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="5">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="6">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="7">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="8">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-          <Value key="9">
-            <Field name="mDesc" xsi:type="array" type="mdesc" size="1">
-              <Value key="0" leave="0" reach="0" />
-            </Field>
-            <Field name="nDuration" xsi:type="array" type="num" size="1" />
-            <Field name="nSequence" xsi:type="array" type="num" size="1" />
-            <Field name="jJointRx" xsi:type="array" type="jointRx" size="1" />
-          </Value>
-        </Field>
-      </Value>
+    <Data name="siTcpIpMotion" access="public" xsi:type="array" type="sio" size="1">
+      <Value key="0" link="Socket\Motion" />
     </Data>
+    <Data name="siTcpIpState" access="public" xsi:type="array" type="sio" size="1">
+      <Value key="0" link="Socket\State" />
+    </Data>
+    <Data name="siTcpIpSystem" access="public" xsi:type="array" type="sio" size="1">
+      <Value key="0" link="Socket\System" />
+    </Data>
+    <Data name="sHeartbeatTask" access="public" xsi:type="array" type="string" size="1">
+      <Value key="0" value="htbtTask" />
+    </Data>
+    <Data name="sIORequestTask" access="public" xsi:type="array" type="string" size="1">
+      <Value key="0" value="ioRequestTask" />
+    </Data>
+    <Data name="sMotionRecvTask" access="public" xsi:type="array" type="string" size="1">
+      <Value key="0" value="motionRecvTask" />
+    </Data>
+    <Data name="sMotionTask" access="public" xsi:type="array" type="string" size="1">
+      <Value key="0" value="motionTask" />
+    </Data>
+    <Data name="sScreenTask" access="public" xsi:type="array" type="string" size="1">
+      <Value key="0" value="screenTask" />
+    </Data>
+    <Data name="sStateMachTask" access="public" xsi:type="array" type="string" size="1">
+      <Value key="0" value="stateTask" />
+    </Data>
+    <Data name="sStreamerTask" access="public" xsi:type="array" type="string" size="1">
+      <Value key="0" value="streamerTask" />
+    </Data>
+    <Data name="sSysRequestTask" access="public" xsi:type="array" type="string" size="1" />
+    <Data name="tTool" access="public" xsi:type="array" type="tool" size="1">
+      <Value key="0" fatherId="flange[0]" ioLink="valve1" />
+    </Data>
+    <Data name="jPosition" access="private" xsi:type="array" type="jointRx" size="1" />
+    <Data name="jSpeed" access="private" xsi:type="array" type="jointRx" size="1" />
   </Datas>
 </Database>

--- a/staubli_val3_driver/val3/ros_server/ros_server.pjx
+++ b/staubli_val3_driver/val3/ros_server/ros_server.pjx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://www.staubli.com/robotics/VAL3/Project/3">
-  <Parameters version="s7.7.2" stackSize="5000" millimeterUnit="true" />
+  <Parameters version="s7.9.1" stackSize="5000" millimeterUnit="true" />
   <Programs>
     <Program file="dataReceiver.pgx" />
     <Program file="dataStreamer.pgx" />
@@ -9,27 +9,33 @@
     <Program file="decTrajPt.pgx" />
     <Program file="decTrajPtFull.pgx" />
     <Program file="encodeAck.pgx" />
+    <Program file="encodeJFeedback.pgx" />
     <Program file="encodeJState.pgx" />
     <Program file="encodeStatus.pgx" />
     <Program file="encPrefixHeader.pgx" />
     <Program file="encTrajPtAck.pgx" />
     <Program file="encTrajPtFAck.pgx" />
     <Program file="fetchStatus.pgx" />
+    <Program file="handleRequest.pgx" />
     <Program file="initParams.pgx" />
+    <Program file="initRosMsgs.pgx" />
     <Program file="motionControl.pgx" />
+    <Program file="motionCtrlVel.pgx" />
+    <Program file="printDebug.pgx" />
     <Program file="pushMotion.pgx" />
     <Program file="recvData.pgx" />
     <Program file="recvHeartbeat.pgx" />
     <Program file="recvMsgBody.pgx" />
     <Program file="recvMsgHeader.pgx" />
+    <Program file="recvRosMsg.pgx" />
     <Program file="recvTrajPt.pgx" />
     <Program file="recvTrajPtFull.pgx" />
     <Program file="screenUpdate.pgx" />
     <Program file="sendAck.pgx" />
     <Program file="sendData.pgx" />
     <Program file="sendRosMsg.pgx" />
-    <Program file="setupRosMsgs.pgx" />
     <Program file="start.pgx" />
+    <Program file="stateMachine.pgx" />
     <Program file="stop.pgx" />
     <Program file="toJointArrayRad.pgx" />
     <Program file="toJointRxDeg.pgx" />
@@ -38,9 +44,13 @@
     <Data file="ros_server.dtx" />
   </Database>
   <Libraries>
+    <Library alias="IO" path="Disk://ros_libs/IOInterface/IOInterface.pjx" />
     <Library alias="libQueueFuncs" path="Disk://ros_libs/QueueFuncs/QueueFuncs.pjx" />
+    <Library alias="Staubli" path="Disk://ros_libs/Staubli/Staubli.pjx" />
+    <Library alias="SimpleMsg" path="Disk://ros_libs/SimpleMessage/SimpleMessage.pjx" />
   </Libraries>
   <Types>
+    <Type name="_MsgRecvState" path="Disk://ros_libs/_MsgRecvState/MsgRecvState.pjx" />
     <Type name="RosSimpleMsg" path="Disk://ros_libs/RosSimpleMsg/RosSimpleMsg.pjx" />
     <Type name="RobotStatusMsg" path="Disk://ros_libs/RobotStatusMsg/RobotStatusMsg.pjx" />
     <Type name="JointStateMsg" path="Disk://ros_libs/JointStateMsg/JointStateMsg.pjx" />
@@ -52,5 +62,7 @@
     <Type name="Prefix" path="Disk://ros_libs/Prefix/Prefix.pjx" />
     <Type name="Body" path="Disk://ros_libs/Body/Body.pjx" />
     <Type name="Queue" path="Disk://ros_libs/Queue/Queue.pjx" />
+    <Type name="MotionCmdVel" path="Disk://ros_libs/MotionCmdVel/MotionCmdVel.pjx" />
+    <Type name="MotionCfgVel" path="Disk://ros_libs/MotionCfgVel/MotionCfgVel.pjx" />
   </Types>
 </Project>

--- a/staubli_val3_driver/val3/ros_server/screenUpdate.pgx
+++ b/staubli_val3_driver/val3/ros_server/screenUpdate.pgx
@@ -1,13 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
-  <Program name="screenUpdate" access="public">
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="screenUpdate" access="public" >
+    <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1" >
+      <Parameter name="x_nPeriod" type="num" use="value" xsi:type="element" dimensions="1" />
+    </Parameters>
     <Locals>
-      <Local name="l_nKey" type="num" xsi:type="array" size="1" />
-      <Local name="l_nExecStatus" type="num" xsi:type="array" size="1" />
       <Local name="l_nElems" type="num" xsi:type="array" size="1" />
+      <Local name="l_nExecStatus" type="num" xsi:type="array" size="1" />
+      <Local name="l_nKey" type="num" xsi:type="array" size="1" />
+      <Local name="l_nIdx" type="num" xsi:type="array" size="1" />
+      <Local name="l_sVelCmdType" type="string" xsi:type="array" size="1" />
     </Locals>
-    <Code><![CDATA[begin  
+    <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -22,147 +28,326 @@
   // limitations under the License.
 
 
+  // screen status indicator
+  l_nExecStatus=0
 
-  l_nExecStatus = 0
+  // setup debug screen
+  nDebugLevel=5
+  nDebugLevelMax=8
+  bDebugMode=false
+  cls(scDebug)
+  title(scDebug,"ROS-I server (DEBUG: Level "+toString("",nDebugLevel)+")")
+  gotoxy(scDebug,0,13)
+  put(scDebug,"BACK")
+  gotoxy(scDebug,16,13)
+  put(scDebug,"CLS")
+  gotoxy(scDebug,31,13)
+  put(scDebug,"-")
+  gotoxy(scDebug,36,13)
+  put(scDebug,"+")
+  gotoxy(scDebug,0,0)
+  nDebugCursor=0
+
+  // setup main screen
   userPage(scMonitor)
   cls(scMonitor)
-  title(scMonitor, "ROS-I server")
-  
+  title(scMonitor,"ROS-I server")
+
   while (true)
-    // clear screen
-    cls(scMonitor)
-    
-    // toggle velocity overwrite upon release of F1 key
-    l_nKey = getKey(scMonitor)
-    call libQueueFuncs:getNumElems(qMoveBuffer,l_nElems)
-    if (l_nKey == 277 and bOverwriteVel == false)
-      if (l_nElems == 0)
-        bOverwriteVel = true
-      else
-        popUpMsg("Motion buffer not empty; cannot enable V/OW")
+    // check whether debug screen is enabled
+    if (bDebugMode)
+      // -----------------------------------------------------
+      // DEBUG SCREEN
+      // -----------------------------------------------------
+      // show the debug screen if not done already
+      if (!bShowDebug)
+        userPage(scDebug)
+        bShowDebug=true
       endIf
-    elseIf (l_nKey == 278 and bOverwriteVel == true)
-      if (l_nElems == 0)
-        bOverwriteVel = false
-      else
-        popUpMsg("Motion buffer not empty; cannot disable V/OW")
-      endIf
-    endIf
-    
-    // update connection status on port 11000
-    gotoxy(scMonitor, 0,0)
-    // 11 characteres: gotoxy(12,0) to insert status
-    put(scMonitor, "Port 11000:")
-    gotoxy(scMonitor, 12,0)
-    switch nInConnFlag
-      case -1
-        put(scMonitor, "connection lost")
-      break
-      case 0
-        put(scMonitor, "not connected")
-      break
-      case 1
-        put(scMonitor, "connected")
-      break
-      default
-        put(scMonitor, "not connected")
-      break
-    endSwitch
-    
-    // update connection status on port 11002
-    gotoxy(scMonitor, 0,1)
-    // 11 characteres: gotoxy(12,1) to insert status
-    put(scMonitor, "Port 11002:")
-    gotoxy(scMonitor, 12,1)
-    switch nOutConnFlag
-      case -1
-        put(scMonitor, "connection lost")
-      break
-      case 0
-        put(scMonitor, "not connected")
-      break
-      case 1
-        put(scMonitor, "connected")
-      break
-      default
-        put(scMonitor, "not connected")
-      break
-    endSwitch
-    
-    // update trajectory buffer size
-    call libQueueFuncs:getNumElems(qTrajPtBuffer,l_nElems)
-    gotoxy(scMonitor, 0,3)
-    // 18 characteres: gotoxy(19,3) to insert status
-    put(scMonitor, "Trajectory buffer:")
-    gotoxy(scMonitor, 19,3)
-    put(scMonitor, l_nElems)
-    // also print number of points popped from buffer
-    gotoxy(scMonitor, 24,3)
-    put(scMonitor, nPtsPopped)
-    // do the same for move buffer
-    call libQueueFuncs:getNumElems(qMoveBuffer,l_nElems)
-    gotoxy(scMonitor, 0,4)
-    put(scMonitor, "Motion buffer:")
-    gotoxy(scMonitor, 19,4)
-    put(scMonitor, l_nElems)
-    gotoxy(scMonitor, 24,4)
-    put(scMonitor, nMovePts)
-    
-    // display velocity overwrite status
-    gotoxy(scMonitor, 0,5)
-    put(scMonitor, "Velocity overwrite:")
-    gotoxy(scMonitor, 20,5)
-    if (bOverwriteVel == true)
-      put(scMonitor, "enabled")
+
+      l_nKey=getKey(scDebug)
+
+      switch (l_nKey)
+        // toggle screen with F1
+        case 271
+          bShowDebug=false
+          bDebugMode=false
+          userPage(scMonitor)
+        break
+        // clear debug screen with F4
+        case 274
+          cls(scDebug)
+          gotoxy(scDebug,0,13)
+          put(scDebug,"BACK")
+          gotoxy(scDebug,16,13)
+          put(scDebug,"CLS")
+          gotoxy(scDebug,31,13)
+          put(scDebug,"-")
+          gotoxy(scDebug,36,13)
+          put(scDebug,"+")
+          gotoxy(scDebug,0,0)
+          nDebugCursor=0
+        break
+        // decrease debug level with F7
+        case 277
+          nDebugLevel=sel(nDebugLevel==0,0,nDebugLevel-1)
+          title(scDebug,"ROS-I server (DEBUG: Level "+toString("",nDebugLevel)+")")
+        break
+        // increase debug level with F8
+        case 278
+          nDebugLevel=sel(nDebugLevel==nDebugLevelMax,nDebugLevelMax,nDebugLevel+1)
+          title(scDebug,"ROS-I server (DEBUG: Level "+toString("",nDebugLevel)+")")
+        break
+        // ignore other keys
+        default
+        break
+      endSwitch
+
     else
-      put(scMonitor, "disabled")
+      // -----------------------------------------------------
+      // MAIN SCREEN
+      // -----------------------------------------------------
+      // clear screen and set title
+      cls(scMonitor)
+      switch (nMotionMode)
+        case Staubli:MotionMode.JOINT_TRAJ
+          title(scMonitor,"ROS-I server [JOINT_TRAJECTORY]")
+        break
+        case Staubli:MotionMode.VELOCITY_CTRL
+          title(scMonitor,"ROS-I server [VELOCITY_CONTROL]")
+        break
+        default
+          title(scMonitor,"ROS-I server")
+        break
+      endSwitch
+
+      // toggle velocity overwrite upon release of F7/F8 keys
+      l_nKey=getKey(scMonitor)
+      call libQueueFuncs:getNumElems(qMoveBuffer,l_nElems)
+      if (l_nKey==277 and bOverwriteVel==false)
+        if (l_nElems==0)
+          bOverwriteVel=true
+        else
+          popUpMsg("Motion buffer not empty; cannot enable V/OW")
+        endIf
+      elseIf (l_nKey==278 and bOverwriteVel==true)
+        if (l_nElems==0)
+          bOverwriteVel=false
+        else
+          popUpMsg("Motion buffer not empty; cannot disable V/OW")
+        endIf
+      endIf
+
+      // switch to debug screen upon release of F1 key
+      if (l_nKey==271)
+        bDebugMode=true
+      endIf
+
+      // update connection status on port 11000
+      gotoxy(scMonitor,0,0)
+      // 15 characters: gotoxy(16,0) to insert status
+      put(scMonitor,"Motion (11000):")
+      gotoxy(scMonitor,16,0)
+      switch nConnFlagMotion
+        case -1
+          put(scMonitor,"connection lost")
+        break
+        case 0
+          put(scMonitor,"not connected")
+        break
+        case 1
+          put(scMonitor,"connected")
+        break
+        default
+          put(scMonitor,"not connected")
+        break
+      endSwitch
+      // update data incoming indicator
+      if (bDataIn)
+        gotoxy(scMonitor,37,0)
+        put(scMonitor,"<<<")
+        bDataIn=false
+      endIf
+
+      // update connection status on port 11001
+      gotoxy(scMonitor,0,1)
+      // 15 characters: gotoxy(16,0) to insert status
+      put(scMonitor,"System (11001):")
+      gotoxy(scMonitor,16,1)
+      switch nConnFlagSystem
+        case -1
+          put(scMonitor,"connection lost")
+        break
+        case 0
+          put(scMonitor,"not connected")
+        break
+        case 1
+          put(scMonitor,"connected")
+        break
+        default
+          put(scMonitor,"not connected")
+        break
+      endSwitch
+
+      // update connection status on port 11002
+      gotoxy(scMonitor,0,2)
+      // 15 characters: gotoxy(16,2) to insert status
+      put(scMonitor,"State  (11002):")
+      gotoxy(scMonitor,16,2)
+      switch nConnFlagState
+        case -1
+          put(scMonitor,"connection lost")
+        break
+        case 0
+          put(scMonitor,"not connected")
+        break
+        case 1
+          put(scMonitor,"connected")
+        break
+        default
+          put(scMonitor,"not connected")
+        break
+      endSwitch
+      // update data outgoing indicator
+      if (bDataOut)
+        gotoxy(scMonitor,37,2)
+        put(scMonitor,">>>")
+        bDataOut=false
+      endIf
+
+      // update connection status on port 11003
+      gotoxy(scMonitor,0,3)
+      // 15 characters: gotoxy(16,3) to insert status
+      put(scMonitor,"IO     (11003):")
+      gotoxy(scMonitor,16,3)
+      switch nConnFlagIO
+        case -1
+          put(scMonitor,"connection lost")
+        break
+        case 0
+          put(scMonitor,"not connected")
+        break
+        case 1
+          put(scMonitor,"connected")
+        break
+        default
+          put(scMonitor,"not connected")
+        break
+      endSwitch
+
+      if (nMotionMode == Staubli:MotionMode.JOINT_TRAJ)
+        // update trajectory buffer size
+        call libQueueFuncs:getNumElems(qTrajPtBuffer,l_nElems)
+        gotoxy(scMonitor,0,5)
+        // 18 characteres: gotoxy(19,3) to insert status
+        put(scMonitor,"Trajectory buffer:")
+        gotoxy(scMonitor,19,5)
+        put(scMonitor,l_nElems)
+        // also print number of points popped from buffer
+        gotoxy(scMonitor,24,5)
+        put(scMonitor,nPtsPopped)
+        // do the same for move buffer
+        call libQueueFuncs:getNumElems(qMoveBuffer,l_nElems)
+        gotoxy(scMonitor,0,6)
+        put(scMonitor,"Motion buffer:")
+        gotoxy(scMonitor,19,6)
+        put(scMonitor,l_nElems)
+        gotoxy(scMonitor,24,6)
+        put(scMonitor,nMovePts)
+
+        // display velocity overwrite status
+        gotoxy(scMonitor,0,7)
+        put(scMonitor,"Velocity overwrite:")
+        gotoxy(scMonitor,20,7)
+        if (bOverwriteVel==true)
+          put(scMonitor,"enabled")
+        else
+          put(scMonitor,"disabled")
+        endIf
+
+        // display nMoveId and nMotionProgress
+        gotoxy(scMonitor,0,8)
+        put(scMonitor,"moveId:")
+        gotoxy(scMonitor,8,8)
+        put(scMonitor,nMoveId)
+        gotoxy(scMonitor,13,8)
+        put(scMonitor,"progress:")
+        gotoxy(scMonitor,23,8)
+        put(scMonitor,nMotionProgress)
+
+      elseIf (nMotionMode == Staubli:MotionMode.VELOCITY_CTRL)
+        // get velocity command type as string
+        switch actMotionCmdVel.nCmdType
+          case Staubli:VelocityType.INVALID
+            l_sVelCmdType = "INVALID"
+          break
+          case Staubli:VelocityType.JOINT
+            l_sVelCmdType = "JOINT"
+          break
+          case Staubli:VelocityType.BASE_FRAME
+            l_sVelCmdType = "BASE_FRAME"
+          break
+          case Staubli:VelocityType.TOOL_FRAME
+            l_sVelCmdType = "TOOL_FRAME"
+          break
+          default
+            l_sVelCmdType = "Unknown=" + toString("", actMotionCmdVel.nCmdType)
+          break
+        endSwitch
+        // print velocity command data and type
+        gotoxy(scMonitor, 0, 5)
+        put(scMonitor, "Velocity Command (" + l_sVelCmdType + "):")
+        for l_nIdx = 0 to 5
+          gotoxy(scMonitor, l_nIdx * 7, 6)
+          put(scMonitor, toString("5", actMotionCmdVel.nVelCmd[l_nIdx]))
+        endFor
+        // print velocity config data
+        gotoxy(scMonitor, 0, 7)
+        put(scMonitor, "Velocity Config (accel,vel,tvel,rvel):")
+        gotoxy(scMonitor, 0, 8)
+        put(scMonitor, "a: "+toString("",motionCfgVel.mMaxSpeed.accel)+" | v: "+toString("",motionCfgVel.mMaxSpeed.vel)+" | t: "+toString("",motionCfgVel.mMaxSpeed.tvel)+" | r: "+toString("",motionCfgVel.mMaxSpeed.rvel))
+      endIf
+
+      
+
+      // display time between valid trajectory point received and ACK sent
+      gotoxy(scMonitor,0,10)
+      put(scMonitor,"recvMsgHeader:")
+      gotoxy(scMonitor,15,10)
+      put(scMonitor,toString(".3",nHeaderTime))
+
+      gotoxy(scMonitor,0,11)
+      put(scMonitor,"other states:")
+      gotoxy(scMonitor,15,11)
+      put(scMonitor,toString(".4",nElapsedTime))
+
+      // update debug status
+      gotoxy(scMonitor,37,11)
+      switch l_nExecStatus
+        case 0
+          put(scMonitor,"[+]")
+          l_nExecStatus=1
+        break
+        case 1
+          put(scMonitor,"[-]")
+          l_nExecStatus=0
+        break
+        default
+        break
+      endSwitch
+
+      // add Function keys labels
+      gotoxy(scMonitor,0,13)
+      put(scMonitor,"DBG")
+      gotoxy(scMonitor,30,13)
+      put(scMonitor,"V/ON")
+      gotoxy(scMonitor,35,13)
+      put(scMonitor,"V/OFF")
+
     endIf
-    
-    // display nMoveId and nMotionProgress
-    gotoxy(scMonitor, 0,7)
-    put(scMonitor, "moveId:")
-    gotoxy(scMonitor, 8,7)
-    put(scMonitor, nMoveId)
-    gotoxy(scMonitor, 13,7)
-    put(scMonitor, "progress:")
-    gotoxy(scMonitor, 23,7)
-    put(scMonitor, nMotionProgress)
-    
-    // display time between valid trajectory point received and ACK sent
-    gotoxy(scMonitor, 0,9)
-    put(scMonitor, "recvMsgHeader:")
-    gotoxy(scMonitor, 15,9)
-    put(scMonitor, toString(".4", nHeaderTime))
-    
-    gotoxy(scMonitor, 0,10)
-    put(scMonitor, "other states:")
-    gotoxy(scMonitor, 15,10)
-    put(scMonitor, toString(".4", nElapsedTime))
-    
-    // update debug status
-    gotoxy(scMonitor, 18,12)
-    switch l_nExecStatus
-      case 0
-        put(scMonitor, "[+]")
-        l_nExecStatus = 1
-      break
-      case 1
-        put(scMonitor, "[-]")
-        l_nExecStatus = 0
-      break
-      default
-      break
-    endSwitch
-    
-    // add Function keys labels
-    gotoxy(scMonitor, 30,13)
-    put(scMonitor, "V/ON")
-    gotoxy(scMonitor, 35,13)
-    put(scMonitor, "V/OFF")
-    
+
     // sequence task
-    //delay(0)
-    delay(0.5)
+    delay(x_nPeriod)
   endWhile
 end]]></Code>
   </Program>

--- a/staubli_val3_driver/val3/ros_server/sendAck.pgx
+++ b/staubli_val3_driver/val3/ros_server/sendAck.pgx
@@ -2,10 +2,14 @@
 <Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2">
   <Program name="sendAck" access="public">
     <Parameters xmlns="http://www.staubli.com/robotics/VAL3/Param/1">
+      <Parameter name="x_sSocket" type="sio" xsi:type="element" use="reference" />
+      <Parameter name="x_nConnFlag" type="num" xsi:type="element" use="reference" />
+      <Parameter name="x_msg" type="RosSimpleMsg" xsi:type="element" use="reference" />
       <Parameter name="x_nMsgRecvState" type="num" xsi:type="element" use="reference" />
     </Parameters>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -21,20 +25,40 @@
 
 
 
-  switch rosGenericMsg.header.nMsgType
-    case 11
-      call sendRosMsg(siTcpIpMotion, rosTrajPtAck.prefix, rosTrajPtAck.header, rosTrajPtAck.body, nInConnFlag)
+  switch x_msg.header.nMsgType
+    case SimpleMsg:MsgType.JOINT_TRAJ_PT
+      call sendRosMsg(x_sSocket, rosTrajPtAck.prefix, rosTrajPtAck.header, rosTrajPtAck.body, x_nConnFlag)
     break
-    case 14
-      call sendRosMsg(siTcpIpMotion, rosTrajPtFAck.prefix, rosTrajPtFAck.header, rosTrajPtFAck.body, nInConnFlag)
+    case SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+      call sendRosMsg(x_sSocket, rosTrajPtFAck.prefix, rosTrajPtFAck.header, rosTrajPtFAck.body, x_nConnFlag)
     break
+    // Staubli specific
+    case Staubli:MsgType.SET_DRIVE_POWER
+      call sendRosMsg(x_sSocket, Staubli:setDrvPwrAck.prefix, Staubli:setDrvPwrAck.header, Staubli:setDrvPwrAck.body, x_nConnFlag)
+    break
+    case Staubli:MsgType.WRITE_SINGLE_IO
+      call sendRosMsg(x_sSocket, Staubli:writeSingIOAck.prefix, Staubli:writeSingIOAck.header, Staubli:writeSingIOAck.body, x_nConnFlag)
+    break
+    case Staubli:MsgType.VELOCITY_CFG
+      call sendRosMsg(x_sSocket, Staubli:velCfgAck.prefix, Staubli:velCfgAck.header, Staubli:velCfgAck.body, x_nConnFlag)
+    break
+    case Staubli:MsgType.VELOCITY_CMD
+      call sendRosMsg(x_sSocket, Staubli:velCmdAck.prefix, Staubli:velCmdAck.header, Staubli:velCmdAck.body, x_nConnFlag)
+    break
+    // default
     default
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel<=5)
+        call printDebug("sendAck: switch (msgType)",true)
+        call printDebug("ERROR: unknown msg type",false)
+      endIf
+      //endregion
     break
   endSwitch
 
   // regardless of result from sending ACK
   // reset state machine to receive new messages
-  x_nMsgRecvState=0
+  x_nMsgRecvState = MsgRecvState.RECEIVE_HEADER
 end]]></Code>
   </Program>
 </Programs>

--- a/staubli_val3_driver/val3/ros_server/sendData.pgx
+++ b/staubli_val3_driver/val3/ros_server/sendData.pgx
@@ -11,6 +11,7 @@
     </Locals>
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -37,6 +38,8 @@
     elseIf (l_nRetVal<size(x_nData))
       popUpMsg("Error while sending data")
       x_nFlag=-1
+    else
+      bDataOut=true
     endIf
   endIf
 end]]></Code>

--- a/staubli_val3_driver/val3/ros_server/start.pgx
+++ b/staubli_val3_driver/val3/ros_server/start.pgx
@@ -3,12 +3,12 @@
   <Program name="start">
     <Locals>
       <Local name="l_nFbkPeriod" type="num" xsi:type="array" size="1" />
-      <Local name="l_nMotionPeriod" type="num" xsi:type="array" size="1" />
-      <Local name="l_nTrajPeriod" type="num" xsi:type="array" size="1" />
+      <Local name="l_nRecvPeriod" type="num" xsi:type="array" size="1" />
       <Local name="l_nScreenUpdate" type="num" xsi:type="array" size="1" />
     </Locals>
     <Code><![CDATA[begin 
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -24,48 +24,62 @@
 
 
 
-  // feedback task will run every 20ms (50Hz)
-  l_nFbkPeriod=0.02
-  //l_nFbkPeriod = 0.032 // 30Hz
-  //l_nFbkPeriod = 0.05  // 20Hz
-  //l_nFbkPeriod = 1.0   //  1Hz
-  
+  // feedback task will run every 4ms (250Hz)
+  l_nFbkPeriod=0.004
+
   // motion control task will run every 4ms (250Hz)
-  l_nMotionPeriod = 0.004
-  //l_nMotionPeriod=0.012  // 83Hz
-  //l_nMotionPeriod = 0.05 // 20Hz
-  
+  nMotionPeriod=0.004
+
   // data (trajectory) reception task will run every 4ms (250Hz)
-  l_nTrajPeriod = 0.004
-  // not in use at the moment
-  l_nScreenUpdate = 1.0
+  l_nRecvPeriod=0.004
 
-  sStreamTaskName = "streamerTask"
-  sTrajPtTaskName = "trajPtTask"
-  sMotionTaskName = "motionTask"
-  sScreenTaskName = "screenTask"
-  sHtbtTaskName = "htbtTask"
+  // screen update task will run every 100ms (10Hz)
+  l_nScreenUpdate=0.1
 
-  // initialise TCP/IP parameters
+  sStreamerTask="streamerTask"
+  sMotionRecvTask="motionRecvTask"
+  sMotionTask="motionTask"
+  sSysRequestTask="sysRequestTask"
+  sIORequestTask="ioRequestTask"
+  sStateMachTask="stateMachTask"
+  sScreenTask="screenTask"
+  sHeartbeatTask="htbtTask"
+
+  // initialize TCP/IP parameters and MsgRecvState enum
   call initParams()
+
+  // initialize libraries (must init SimpleMsg first! Staubli is dependent on SimpleMsg)
+  call SimpleMsg:init()
+  call Staubli:init()
+  call IO:init()
   // setup prefix and header of ROS messages
-  call setupRosMsgs()
-  
+  call initRosMsgs()
+
+  // set standard motion mode
+  nMotionMode=Staubli:MotionMode.JOINT_TRAJ
+
   // socket connection status flags: initially disconnected
-  nInConnFlag = 0
-  nOutConnFlag = 0
-  
+  nConnFlagIO = 0
+  nConnFlagMotion = 0
+  nConnFlagState = 0
+  nConnFlagSystem = 0
+
+  // flags defining whether data being received/sent
+  bDataIn = false
+  bDataOut = false
+
   // flag defining whether velocity to be overwritten to max. vel.
   bOverwriteVel = false
-  
-  nPtsPopped = 0
-  nMovePts = 0
 
-  // flush buffer of incoming socket
+  nPtsPopped=0
+  nMovePts=0
+
+  // flush buffers of sockets
+  clearBuffer(siTcpIpIO)
   clearBuffer(siTcpIpMotion)
-  // flush buffer of outgoing socket
-  clearBuffer(siTcpIpFbk)
-  
+  clearBuffer(siTcpIpState)
+  clearBuffer(siTcpIpSystem)
+
   // check if robot is not in emergency stop and wait until estop is reset
   if (esStatus() == 2)
     popUpMsg("Please reset E-Stop")
@@ -88,21 +102,28 @@
   resetMotion()
 
   // create joint state and robot status streamer task to send data to industrial_robot_client
-  taskCreateSync sStreamTaskName, l_nFbkPeriod, bFbkOverrun, dataStreamer()
-  
-  // create trajectory point task to receive data from industrial_robot_client
-  taskCreateSync sTrajPtTaskName, l_nTrajPeriod, bTrajPtOverrun, dataReceiver()
-  //taskCreate sTrajPtTaskName, 100, dataReceiver()
-  
-  // create motion task to synchronously apply motion commands to robot
-  taskCreateSync sMotionTaskName, l_nMotionPeriod, bMotionOverrun, motionControl()
+  taskCreateSync sStreamerTask, l_nFbkPeriod, bFbkOverrun, dataStreamer()
 
-  // create synchronous task to update screen
-  //taskCreateSync sScreenTaskName, l_nScreenUpdate, bScreenOverrun, screenUpdate()
-  taskCreate sScreenTaskName, 10, screenUpdate()
-  
+  // create receiver task for motion commands (e.g. from industrial_robot_client)
+  taskCreateSync sMotionRecvTask, l_nRecvPeriod, bRecvOverrun, dataReceiver(siTcpIpMotion, nConnFlagMotion, genericMotMsg)
+
+  // create motion task to synchronously apply motion commands to robot
+  taskCreateSync sMotionTask, nMotionPeriod, bMotionOverrun, motionControl()
+
+  // create asynchronous task to handle state transition
+  taskCreate sStateMachTask, 100, stateMachine()
+
+  // create asynchronous task to handle system requests
+  taskCreate sSysRequestTask, 100, dataReceiver(siTcpIpSystem, nConnFlagSystem, genericSysMsg)
+
+  // create asynchronous task to handle io requests
+  taskCreate sIORequestTask, 100, dataReceiver(siTcpIpIO, nConnFlagIO, genericIOMsg)
+
+  // create asynchronous task to update screen
+  taskCreate sScreenTask, 10, screenUpdate(l_nScreenUpdate)
+
   // create asynchronous task to receive heartbeat on port 11002
-  taskCreate sHtbtTaskName, 10, recvHeartbeat()
+  taskCreate sHeartbeatTask, 10, recvHeartbeat()
 
 end]]></Code>
   </Program>

--- a/staubli_val3_driver/val3/ros_server/stateMachine.pgx
+++ b/staubli_val3_driver/val3/ros_server/stateMachine.pgx
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Programs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.staubli.com/robotics/VAL3/Program/2" >
+  <Program name="stateMachine" access="private" >
+    <Locals>
+      <Local name="l_bKillMotTask" type="bool" xsi:type="array" size="1" />
+      <Local name="l_bOk" type="bool" xsi:type="array" size="1" />
+      <Local name="l_bResetMotion" type="bool" xsi:type="array" size="1" />
+      <Local name="l_nNextState" type="num" xsi:type="array" size="1" />
+    </Locals>
+    <Code><![CDATA[begin
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // you may not use this file except in compliance with the License.
+  // You may obtain a copy of the License at
+  //
+  //     http://www.apache.org/licenses/LICENSE-2.0
+  //
+  // Unless required by applicable law or agreed to in writing, software
+  // distributed under the License is distributed on an "AS IS" BASIS,
+  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  // See the License for the specific language governing permissions and
+  // limitations under the License.
+
+
+  while (true)
+    // assume success to state transition
+    l_bOk=true
+    // reset flags
+    l_bKillMotTask=false
+    l_bResetMotion=false
+    // wait for state transition event
+    wait(bMotionMsgEvent)
+    bMotionMsgEvent=false
+
+    // //region @DEBUG
+    // if (bDebugMode and nDebugLevel==7)
+      // call printDebug("stateMachine: got event ("+toString("",nMotionMsgType)+")",true)
+      // call printDebug("INFO: current state: "+toString("",nMotionMode),false)
+    // endIf
+    // //endregion
+
+    //region @switch_current_state -- check whether the current motion task has to be killed
+    //                                and set next state
+    if (nMotionMode==Staubli:MotionMode.JOINT_TRAJ)
+
+      switch (nMotionMsgType)
+        case SimpleMsg:MsgType.JOINT_TRAJ_PT,SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+          // already in JOINT_TRAJ mode, skip state transition
+          l_bOk=false
+        break
+        case Staubli:MsgType.VELOCITY_CFG
+          l_bKillMotTask=true
+          l_nNextState=Staubli:MotionMode.VELOCITY_CTRL
+        break
+      endSwitch
+
+    elseIf (nMotionMode==Staubli:MotionMode.VELOCITY_CTRL)
+
+      switch (nMotionMsgType)
+        case SimpleMsg:MsgType.JOINT_TRAJ_PT,SimpleMsg:MsgType.JOINT_TRAJ_PT_F
+          l_bKillMotTask=true
+          l_nNextState=Staubli:MotionMode.JOINT_TRAJ
+        break
+        case Staubli:MsgType.VELOCITY_CFG
+          l_bResetMotion=true
+        break
+      endSwitch
+
+    endIf
+    //endregion @switch_current_state
+
+    // check whether to continue
+    if (l_bOk)
+
+      //region @DEBUG
+      if (bDebugMode and nDebugLevel==7)
+        call printDebug("INFO: state transition ("+toString("",nMotionMode)+" -> "+toString("",l_nNextState)+")",false)
+      endIf
+      //endregion
+
+      //region @clean_up_motion_task -- if so force motion task to reset motion and/or kill the task
+      if (l_bResetMotion)
+        // set stop flag (important for velocity mode: reconfiguration without killing task)
+        bStopNow=true
+      elseIf (l_bKillMotTask)
+        // if the current motion task has to be killed, wait until it finishes cleaning up
+        bStopNow=true
+        wait(bStopNow==false)
+        // ... and then kill the task
+        taskKill(sMotionTask)
+        resetMotion()
+
+        //region @DEBUG
+        if (bDebugMode and nDebugLevel==7)
+          call printDebug("INFO: motion task killed",false)
+        endIf
+        //endregion
+      endIf
+      //endregion
+
+      //region @create_new_motion_task -- create the new motion task if required
+      if (l_bKillMotTask)
+        switch l_nNextState
+          case Staubli:MotionMode.JOINT_TRAJ
+            taskCreateSync sMotionTask,nMotionPeriod,bMotionOverrun,motionControl()
+          break
+          case Staubli:MotionMode.VELOCITY_CTRL
+            taskCreateSync sMotionTask,nMotionPeriod,bMotionOverrun,motionCtrlVel()
+          break
+          default
+            l_bOk=false
+            //region @DEBUG
+            if (bDebugMode and nDebugLevel==7)
+              call printDebug("ERROR: unknown next state",false)
+            endIf
+            //endregion
+          break
+        endSwitch
+
+        //region @DEBUG
+        if (bDebugMode and nDebugLevel==7)
+          if (l_bOk)
+            call printDebug("INFO: new motion task created",false)
+          else
+            call printDebug("ERROR: new motion task not created",false)
+          endIf
+        endIf
+        //endregion
+      endIf
+      //endregion
+
+      // finally update current state if successful
+      if (l_bOk)
+        if (l_nNextState!=Staubli:MotionMode.INVALID)
+          nMotionMode=l_nNextState
+
+          //region @DEBUG
+          if (bDebugMode and nDebugLevel==7)
+            call printDebug("INFO: set new state ("+toString("",l_nNextState)+")",false)
+          endIf
+          //endregion
+        else
+          //region @DEBUG
+          if (bDebugMode and nDebugLevel==7)
+            call printDebug("WARN: state not set -> invalid ("+toString("",l_nNextState)+")",false)
+          endIf
+          //endregion
+        endIf
+      endIf
+
+    endIf
+
+    // sequence task
+    delay(0)
+  endWhile
+end]]></Code>
+  </Program>
+</Programs>

--- a/staubli_val3_driver/val3/ros_server/stop.pgx
+++ b/staubli_val3_driver/val3/ros_server/stop.pgx
@@ -3,6 +3,7 @@
   <Program name="stop" access="private" >
     <Code><![CDATA[begin
   // Copyright (c) 2016, Ocado Technology - Robotics Research Team
+  // Copyright (c) 2021, Institute for Factory Automation and Production Systems (FAPS)
   //
   // Licensed under the Apache License, Version 2.0 (the "License");
   // you may not use this file except in compliance with the License.
@@ -20,7 +21,8 @@
 
   resetMotion()
   popUpMsg("Pending movement commands have been cancelled.")
-  cls()
+  userPage(scMonitor)
+  cls(scMonitor)
 end]]></Code>
   </Program>
 </Programs>


### PR DESCRIPTION
### VAL3

- Velocity control implemented with functions for velocity commands -> requires add-on (Velocity or Motion)!
- Velocity control possible in joint space (JOINT) or cartesian space (w.r.t. BASE/TOOL frame)
- Velocity control mode is started with a VelocityConfig message with various parameters (e.g. vel/accel limits)
- Added state machine to switch between motion control modes (JOINT_TRAJECTORY_STREAMING, VELOCITY_CONTROL)
  -> the default mode is JOINT_TRAJECTORY_STREAMING and works as before
- Increased feedback task frequency (synced with interpolation clock)
- SYSTEM socket interface (receiver task, port 11001) to handle system commands (e.g. set drive power)
- IO socket interface (receiver task, port 11003) to handle IO commands (e.g. read/write IO)
  -> only writing single IO is fully implemented

Other changes/improvements:

- Sending JointFeedback message including joint velocities -> requires add-on (Motion)!
  Note: The generic industrial_robot_client doesn't support JointFeedback messages
- Renamed socket name "Feedback" -> "State" (socket configuration must be adapted on the controller!)
- Used VAL3 libraries and custom types for better modularization
- Used VAL3 custom types for "enums"
- Added debug screen for debug messages (switching to the debug screen activates the "debug mode")

*NOTE: Developed and tested on a CS8 Controller only!*

### ROS-Industrial clients

- robot_state node with additional support for JointFeedback messages
- IO interface for reading/writing IO (only "write single IO" fully implemented)
- system interface for system commands ("set drive power" implemented)
- added staubli_msgs package (with IO related messages/services)