### PR TITLE
allow velocity override

### DIFF
--- a/staubli_val3_driver/val3/ros_server/pushMotion.pgx
+++ b/staubli_val3_driver/val3/ros_server/pushMotion.pgx
@@ -72,7 +72,7 @@
     // check whether velocity value should be overwritten with value set on teach pendant
     if(bOverwriteVel == true)
       // overwrite velocity (and acceleration - ?)
-      //l_mTrajPt.mDesc.vel = getMonitorSpeed()
+      l_mTrajPt.mDesc.vel = getMonitorSpeed()
       // explicitly setting accel and decel to VAL3 default values
       l_mTrajPt.mDesc.accel = mNomSpeed.accel
       l_mTrajPt.mDesc.decel = mNomSpeed.decel


### PR DESCRIPTION
the velocity override was commented out without further description in https://github.com/ros-industrial/staubli_val3_driver/commit/4cbb7f92143987360ae85ea0bcb825275c08acf0 by @marshallpowell97 

as our customer is not seeing attractive velocities (similar to #30 I assume but I did not yet capture details) we wanted to use the velocity override mode by changing this line
https://github.com/ros-industrial/staubli_val3_driver/blob/7913f147663f6d54279cfb77cf90ecfb32454313/staubli_val3_driver/val3/ros_server/start.pgx#L91