### PR TITLE
Increase minimum CMake version to allow builds on Focal Fossa (Noetic)

### DIFF
--- a/staubli_val3_driver/CMakeLists.txt
+++ b/staubli_val3_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(staubli_val3_driver)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
Related to https://github.com/ros-industrial/ros_industrial_issues/issues/67